### PR TITLE
Fix runner id key error

### DIFF
--- a/src/read_buckets.py
+++ b/src/read_buckets.py
@@ -107,7 +107,7 @@ def bucket_reader_md(tablestr: str, runner: str) -> None:
 
 """
     create_markdown_artifact(
-        key=f"bucket-reader-report-{runner}",
+        key=f"bucket-reader-report-{runner.lower().replace('_','-').replace(' ','-').replace('.','-')}",
         markdown=markdown_report,
         description=f"Bucker Reader Report for {runner}",
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -349,7 +349,7 @@ def markdown_template_updater(
 
 """
     create_markdown_artifact(
-        key=f"{runner.lower().replace('_','-').replace(' ','-')}-template-updater-summary",
+        key=f"{runner.lower().replace('_','-').replace(' ','-').replace('.','-')}-template-updater-summary",
         markdown=markdown_report,
         description=f"{runner} template updater worklfow summary",
     )
@@ -385,7 +385,7 @@ def markdown_input_task(
 {sra_template}
 """
     create_markdown_artifact(
-        key=f"{runner.lower().replace('_','-').replace(' ','-')}-workflow-input-report",
+        key=f"{runner.lower().replace('_','-').replace(' ','-').replace('.','-')}-workflow-input-report",
         markdown=markdown_report,
         description=f"{runner} workflow input report",
     )
@@ -616,7 +616,7 @@ def markdown_output_task(
 
 """
     create_markdown_artifact(
-        key=f"{runner.lower().replace('_','-').replace(' ','-')}-workflow-output-report",
+        key=f"{runner.lower().replace('_','-').replace(' ','-').replace('.','-')}-workflow-output-report",
         markdown=markdown_report,
         description=f"{runner} workflow output report",
     )


### PR DESCRIPTION
Added Features

- The prefect artifact key only allows lowercase letter, number and dash. As the artifact key includes runner id as part of the key, the change replaces all the space ` `, dot `.` and underscore `_` in the runner id with dash `-`