### PR TITLE
Update s3_ccdi_to_sra.py

### DIFF
--- a/src/s3_ccdi_to_sra.py
+++ b/src/s3_ccdi_to_sra.py
@@ -786,7 +786,7 @@ def check_value_constancy(library_id: str, unit_df: DataFrame, logger) -> None:
             pass
     if len(cols_to_report) > 0:
         logger.warning(
-            f"Files from library {library_id} have different values for {*cols_to_report,}"
+            f"Files from library {library_id} have different values for {*cols_to_report,}. Because SRA submission requires files from the same libary id to be submitted in a single line, the output uses the first row of the table shown below."
         )
         logger.warning(
             f"Additional info:\n"


### PR DESCRIPTION
Additional logging info for SRA warns user that the output uses the property values of the first file among files sharing the same library ID, even if they have different values for certain properties, such as `Bases`, `Reads` etc.