### PR TITLE
Ccdidc 791 file mover

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -133,7 +133,7 @@ deployments:
 
   - name: file-mover
     version: null
-    tags: ["Test"]
+    tags: ["Production"]
     description: null
     entrypoint: workflows/File_Mover.py:file_mover
     schedule: null

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -130,3 +130,34 @@ deployments:
       name: ccdi-curation-ecs
       work_queue_name: null
       job_variables: {}
+
+  - name: file-mover
+    version: null
+    tags: ["Test"]
+    description: null
+    entrypoint: workflows/File_Mover.py:file_mover
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+      file_path: ""
+      runner: "your_uniq_id"
+      dest_bucket_path: "your_dest_bucket/sub_dir"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.projects.steps.git_clone_project:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: CCDIDC-791_file_mover
+      - prefect.projects.steps.pip_install_requirements:
+          requirements_file: requirements.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-curation-ecs
+      work_queue_name: null
+      job_variables: {}

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -1,0 +1,254 @@
+import os
+import sys
+from src.utils import CheckCCDI, set_s3_session_client, get_logger, get_date, get_time
+from botocore.exceptions import ClientError
+from urllib.parse import urlparse
+from shutil import copy
+import numpy as np
+import pandas as pd
+import json
+import hashlib
+from prefect import flow
+
+
+def parse_file_url_in_cds(url: str) -> tuple:
+    parsed_url = urlparse(url)
+    bucket_name = parsed_url.netloc
+    object_key = parsed_url.path
+    if object_key[0] == "/":
+        object_key = object_key[1:]
+    else:
+        pass
+    return bucket_name, object_key
+
+
+def calculate_object_md5sum(s3_client, url) -> str:
+    """Calculate md5sum of an object using url
+
+    Example of url:
+    s3://example-bucket/folder1/folder2/test_file.fastq.gz
+    """
+    bucket_name, object_key = parse_file_url_in_cds(url)
+    # get obejct
+    obj = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+    obj_body = obj["Body"]
+
+    # Initialize MD5 hash object
+    md5_hash = hashlib.md5()
+    # Read the object in chunks and update the MD5 hash
+    for chunk in iter(lambda: obj_body.read(1024 * 1024), b""):
+        md5_hash.update(chunk)
+    return md5_hash.hexdigest()
+
+
+def compare_md5sum(first_url: str, second_url: str, s3_client) -> bool:
+    """Compares the md5sum of two objects"""
+    first_md5sum = calculate_object_md5sum(s3_client=s3_client, url=first_url)
+    second_md5sum = calculate_object_md5sum(s3_client=s3_client, url=second_url)
+    if first_md5sum == second_md5sum:
+        return first_md5sum, second_md5sum, True
+    else:
+        return (first_md5sum, second_md5sum, False)
+
+
+def copy_object_parameter(url_in_cds: str, dest_bucket_path: str) -> dict:
+    """Returns a dict that can be used as parameter for copy object using s3 client
+
+    Example
+    mydict=copy_object_parameter(origin_bucket=ccdi-validation, object_key="QL/file2.txt",
+                                 dest_bucket_path="my-source-bucket/new_release")
+    Expected Return
+    {
+        'Bucket': 'my-source-bucket',
+        'CopySource': 'ccdi-validation/QL/file2.txt',
+        'Key': 'new_release/QL/file2.txt'
+     }
+    """
+    origin_bucket, object_key = parse_file_url_in_cds(url=url_in_cds)
+    dest_bucket, dest_prefix = dest_bucket_path.split("/", 1)
+    copysource = os.path.join(origin_bucket, object_key)
+    dest_key = os.path.join(dest_prefix, object_key)
+    param_dict = {"Bucket": dest_bucket, "CopySource": copysource, "Key": dest_key}
+    return param_dict
+
+
+def dest_object_url(url_in_cds: str, dest_bucket_path: str) -> str:
+    """Returns an url of object in destination bucket
+    object_key is the path of object in original bucket(without bucket name)
+
+    Example:
+    dest_url =  dest_object_url(object_key="QL/inputs/file1.txt", dest_bucket_path="new-bucket/release5")
+    Expected Return
+    "s3://new-bucket/release5/QL/inputs/file1.txt"
+    """
+    orgin_bucket, object_key = parse_file_url_in_cds(url=url_in_cds)
+    dest_url = os.path.join("s3://", dest_bucket_path, object_key)
+    return dest_url
+
+
+@flow(
+    name="Move Manifest Files",
+    log_prints=True,
+    flow_run_name="move-manifest-files-" + f"{get_time()}",
+)
+def move_manifest_files(manifest_path: str, dest_bucket_path: str):
+    """Checks file node sheets and replaces the "file_url_in_cds"
+    with a new url in prod bucket
+    Returns a new manifest with new
+    """
+    # create logger
+    logger = get_logger(loggername="file_mover_workflow", log_level="info")
+    logger_filename = "file_mover_workflow_" + get_date() + ".log"
+
+    # Create output file
+    ccdi_file = CheckCCDI(ccdi_manifest=manifest_path)
+    # identify file nodes
+    file_nodes = ccdi_file.find_file_nodes()
+
+    # create output file
+    output_name = (
+        os.path.basename(manifest_path).rsplit(".", 1)[0]
+        + "_FileMoved"
+        + get_date()
+        + "."
+        + os.path.basename(manifest_path).rsplit(".", 1)[1]
+    )
+    copy(src=manifest_path, dst=output_name)
+
+    # create an empty df
+    transfer_df = pd.DataFrame(
+        columns=[
+            "node",
+            "url_before_cp",
+            "url_after_cp",
+            "transfer_status",
+            "cp_object_parameter",
+        ]
+    )
+    # we assume file nodes list exists
+    for node in file_nodes:
+        node_df = ccdi_file.read_sheet_na(sheetname=node)
+        # in case this is an empty sheet and only "type" column is populated with one entry
+        node_df_rmna = node_df.drop(columns=["type"]).dropna(axis=0, how="all")
+        if node_df_rmna.shape[0] >= 1:
+            logger.info(
+                f"Number of file objects in node {node}: {node_df_rmna.shape[0]}"
+            )
+            node_file_urls = node_df["file_url_in_cds"].tolist()
+            new_node_file_urls = [
+                dest_object_url(url_in_cds=i, dest_bucket_path=dest_bucket_path)
+                for i in node_file_urls
+            ]
+            node_file_param_dict = [
+                copy_object_parameter(url_in_cds=i, dest_bucket_path=dest_bucket_path)
+                for i in node_file_urls
+            ]
+            node_transfer_df = pd.DataFrame(
+                {
+                    "node": [node] * node_df.shape[0],
+                    "url_before_cp": node_file_urls,
+                    "url_after_cp": new_node_file_urls,
+                    "cp_object_parameter": node_file_param_dict,
+                    "transfer_status": [np.nan] * node_df.shape[0],
+                }
+            )
+            # concatenate node_transfer_df to transfer_df
+            transfer_df = pd.concat([transfer_df, node_transfer_df], ignore_index=True)
+            # replace the old url with new url in the output
+            node_df["file_url_in_cds"] = new_node_file_urls
+            with pd.ExcelWriter(
+                output_name, mode="a", engine="openpyxl", if_sheet_exists="overlay"
+            ) as writer:
+                node_df.to_excel(
+                    writer, sheet_name=node, index=False, header=False, startrow=1
+                )
+        else:
+            logger.info(f"Number of file objects in node {node}: 0")
+    logger.info(
+        f"A CCDI Excel manifest with new object urls was generated {output_name}"
+    )
+
+    # File transfer starts
+    logger.info(f"Start transfering files to destination bucket {dest_bucket_path}")
+    s3_client = set_s3_session_client()
+    success_transfer_ct = 0
+    fail_transfer_ct = 0
+    for index, row in transfer_df.iterrows():
+        row_cp_parameter = row["cp_object_parameter"]
+        try:
+            response = s3_client.copy_object(**row_cp_parameter)
+            transfer_df.loc[index, "transfer_status"] = "Success"
+            success_transfer_ct += 1
+        except ClientError as ex:
+            ex_code = ex.response["Error"]["Code"]
+            ex_message = ex.response["Error"]["Message"]
+            failed_file = row["url_before_cp"]
+            if ex_code == "NoSuchKey":
+                object_name = ex.response["Error"]["Key"]
+                logger.error(ex_code + ":" + ex_message + " " + object_name)
+            elif ex_code == "NoSuchBucket":
+                bucket_name = ex.response["Error"]["Code"]["BucketName"]
+                logger.error(
+                    ex_code + ":" + ex_message + " Bucket name: " + bucket_name
+                )
+            else:
+                logger.error(
+                    "Error info:\n" + json.dumps(ex.response["Error"], indent=4)
+                )
+            transfer_df.loc[index, "transfer_status"] = "Fail"
+            fail_transfer_ct += 1
+    logger.info(f"Successfully transferred {success_transfer_ct} files")
+    if fail_transfer_ct >= 1:
+        logger.warning(f"Failed to transfer {fail_transfer_ct} files")
+    else:
+        pass
+
+    # Check md5sum of file before transfer and after transfer
+    # md5sum check only checks files which have been successfully copied between buckets
+    logger.info("Start checking md5sum before and after transfer")
+    transfer_df["md5sum_check"] = [""] * transfer_df.shape[0]
+    transfer_df["md5sum_before_cp"] = [""] * transfer_df.shape[0]
+    transfer_df["md5sum_after_cp"] = [""] * transfer_df.shape[0]
+    for index, row in transfer_df.iterrows():
+        if row["transfer_status"] == "Fail":
+            pass
+        else:
+            url_before = row["url_before_cp"]
+            url_after = row["url_after_cp"]
+            before_md5sum, after_md5sum, compare_result = compare_md5sum(
+                first_url=url_before, second_url=url_after, s3_client=s3_client
+            )
+            if compare_result:
+                transfer_df.loc[index, "md5sum_check"] = "Pass"
+            else:
+                transfer_df.loc[index, "md5sum_check"] = "Fail"
+            transfer_df.loc[index, "md5sum_before_cp"] = before_md5sum
+            transfer_df.loc[index, "md5sum_after_cp"] = after_md5sum
+    passed_md5sum_check_ct = sum(transfer_df["md5sum_check"] == "Pass")
+    failed_md5sum_check_ct = sum(transfer_df["md5sum_check"] == "Fail")
+    logger.info(f"md5sum check passed files: {passed_md5sum_check_ct}")
+    if failed_md5sum_check_ct >= 1:
+        logger.warning(f"md5sum check failed files: {failed_md5sum_check_ct}")
+    else:
+        pass
+
+    # write transfer summary table
+    mover_summary_table = (
+        os.path.basename(manifest_path).rsplit(".", 1)[0]
+        + "_FileMover_Summary_" + get_date() + ".tsv"
+    )
+    transfer_df[
+        [
+            "node",
+            "url_before_cp",
+            "url_after_cp",
+            "transfer_status",
+            "md5sum_check",
+            "md5sum_before_cp",
+            "md5sum_after_cp",
+        ]
+    ].to_csv(mover_summary_table, sep="\t", index=False)
+    logger.info(f"File mover summary table was created {mover_summary_table}")
+    del transfer_df
+    return output_name, logger_filename, mover_summary_table
+

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -24,6 +24,7 @@ def parse_file_url_in_cds(url: str) -> tuple:
 
 def calculate_object_md5sum(s3_client, url) -> str:
     """Calculate md5sum of an object using url
+    This function was modified based on https://github.com/jmwarfe/s3-md5sum/blob/main/s3-md5sum.py
 
     Example of url:
     s3://example-bucket/folder1/folder2/test_file.fastq.gz
@@ -251,4 +252,3 @@ def move_manifest_files(manifest_path: str, dest_bucket_path: str):
     logger.info(f"File mover summary table was created {mover_summary_table}")
     del transfer_df
     return output_name, logger_filename, mover_summary_table
-

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import List, TypeVar, Dict, Tuple
 import warnings
 import os
+import sys
 from datetime import date
 from datetime import datetime
 from pytz import timezone
@@ -778,16 +779,16 @@ def get_logger(loggername: str, log_level: str):
     logger = logging.getLogger(loggername)
     logger.setLevel(log_levels[log_level])
 
-    # set the stream handler
-    # stream_handler = logging.StreamHandler(sys.stdout)
-    # stream_handler.setFormatter(ColorLogFormatter())
-    # stream_handler.setLevel(log_levels["info"])
-
     # set the file handler
     file_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
     file_handler = logging.FileHandler(logger_filename, mode="w")
     file_handler.setFormatter(logging.Formatter(file_FORMAT, "%H:%M:%S"))
     file_handler.setLevel(log_levels["info"])
+
+    # set the stream handler
+    # stream_handler = logging.StreamHandler(sys.stdout)
+    # stream_handler.setFormatter(logging.Formatter(file_FORMAT, "%H:%M:%S"))
+    # stream_handler.setLevel(log_levels["info"])
 
     # logger.addHandler(stream_handler)
     logger.addHandler(file_handler)
@@ -912,3 +913,10 @@ class CheckCCDI:
         else:
             pass
         return term_dict
+
+    def find_file_nodes(self):
+        dict_df =  self.get_dict_df()
+        file_node_list = dict_df[dict_df["Property"] == "file_url_in_cds"]["Node"].tolist()
+        # remove any duplcates
+        file_node_list_uniq = list(set(file_node_list))
+        return file_node_list_uniq

--- a/tests/test_file_mover.py
+++ b/tests/test_file_mover.py
@@ -1,0 +1,63 @@
+import sys
+import os
+import mock
+import pytest
+from unittest.mock import MagicMock
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(parent_dir)
+from src.file_mover import (
+    parse_file_url_in_cds,
+    dest_object_url,
+    compare_md5sum,
+)
+
+
+def test_parse_url():
+    """test for parse_file_url_in_cds()"""
+    bucket_name, object_key = parse_file_url_in_cds(
+        "s3://mytest-bucket/folder_1/folder2/test_object.fastq"
+    )
+    assert bucket_name == "mytest-bucket"
+    assert object_key == "folder_1/folder2/test_object.fastq"
+
+
+def test_dest_object_url():
+    """test for dest_object_url"""
+    dest_url = dest_object_url(
+        url_in_cds="s3://origin-bucket/subdir1/subdir/test_object.fastq",
+        dest_bucket_path="dest-bucket/test_dir",
+    )
+    assert dest_url == "s3://dest-bucket/test_dir/subdir1/subdir/test_object.fastq"
+
+
+@mock.patch("src.utils.set_s3_session_client", autospec=True)
+@mock.patch("src.file_mover.calculate_object_md5sum", autospec=True)
+def test_compare_md5sum_same(mock_md5sum_calculator, mock_s3_client):
+    """test for compare_md5sum"""
+    mock_md5sum_calculator.side_effect = [
+        "94da06b53eddd226f8e637e3ec85b7ce",
+        "94da06b53eddd226f8e637e3ec85b7ce",
+    ]
+    s3_client = mock_s3_client.return_value
+    first_md5sum, _ , compare_result = compare_md5sum(
+        first_url="myfirst_url", second_url="mysecond_url", s3_client=s3_client
+    )
+    assert compare_result
+    assert first_md5sum == "94da06b53eddd226f8e637e3ec85b7ce"
+
+
+@mock.patch("src.utils.set_s3_session_client", autospec=True)
+@mock.patch("src.file_mover.calculate_object_md5sum", autospec=True)
+def test_compare_md5sum_different(mock_md5sum_calculator, mock_s3_client):
+    """test for compare_md5sum"""
+    mock_md5sum_calculator.side_effect = [
+        "94da06b53eddd226f8e637e3ec85b7ce",
+        "94da06b53eddd226f8e637e3ec85b7cg",
+    ]
+    s3_client = mock_s3_client.return_value
+    _ , second_md5sum, compare_result = compare_md5sum(
+        first_url="myfirst_url", second_url="mysecond_url", s3_client=s3_client
+    )
+    assert not compare_result
+    assert second_md5sum == "94da06b53eddd226f8e637e3ec85b7cg"

--- a/workflows/File_Mover.py
+++ b/workflows/File_Mover.py
@@ -53,6 +53,7 @@ def file_mover(bucket: str, file_path: str, runner: str, dest_bucket_path: str) 
     runner_logger.info(
         f"Uploaded {summary_table} to bucket {bucket} folder {output_folder}"
     )
+    runner_logger.info(f"File mover workflow has FINISHED! Modified CCDI manifest, summary table tsv, and workflow log can be found at {output_folder}")
 
 
 if __name__=="__main__":

--- a/workflows/File_Mover.py
+++ b/workflows/File_Mover.py
@@ -1,0 +1,64 @@
+from prefect import flow, task, get_run_logger
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(parent_dir)
+from src.file_mover import move_manifest_files
+from src.utils import get_time, file_dl, file_ul
+
+
+@flow(
+    name="File Mover",
+    log_prints=True,
+    flow_run_name="file-mover-{runner}-" + f"{get_time()}",
+)
+def file_mover(bucket: str, file_path: str, runner: str, dest_bucket_path: str) -> None:
+    # create a logging object
+    runner_logger = get_run_logger()
+
+    # download the manifest
+    file_dl(bucket, file_path)
+    runner_logger.info(f"Downloaded manifest from bucket {bucket} at {file_path}")
+
+    manifest_path = os.path.basename(file_path)
+
+    # Start file moving and generating new files
+    modified_manifest, mover_log, summary_table =  move_manifest_files(manifest_path=manifest_path, dest_bucket_path=dest_bucket_path)
+
+    # upload files to bucket
+    output_folder = os.path.join(runner, "file_mover_outputs_" + get_time())
+    file_ul(
+        bucket=bucket,
+        output_folder=output_folder,
+        sub_folder="",
+        newfile=modified_manifest
+    )
+    runner_logger.info(f"Uploaded {modified_manifest} to bucket {bucket} folder {output_folder}")
+    file_ul(
+        bucket=bucket,
+        output_folder=output_folder,
+        sub_folder="",
+        newfile=mover_log,
+    )
+    runner_logger.info(
+        f"Uploaded {mover_log} to bucket {bucket} folder {output_folder}"
+    )
+    file_ul(
+        bucket=bucket,
+        output_folder=output_folder,
+        sub_folder="",
+        newfile=summary_table,
+    )
+    runner_logger.info(
+        f"Uploaded {summary_table} to bucket {bucket} folder {output_folder}"
+    )
+
+
+if __name__=="__main__":
+    bucket="my-source-bucket"
+    file_path="inputs/testing_manifest.xlsx"
+    runner="QL"
+    dest_bucket_path = "my-dest-bucket/new-release"
+
+    file_mover(bucket=bucket, file_path=file_path, runner=runner, dest_bucket_path=dest_bucket_path)


### PR DESCRIPTION
Added Features

- Added new workflow `file-mover` which takes CCDI manifest and destination bucket folder path as input and copys file objects from the staging bucket to the destination bucket path. The workflow performs md5sum check before and after file copying.
- The workflow produces 3 outputs: `new CCDI manifest with modified bucket urls`, `logging file`, and `a file transferring summary table tsv`.