### PR TITLE
Ccdidc 859 keep header style

### DIFF
--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -594,9 +594,6 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
         for sheet_name in meta_dfs.keys():
             sheet_df = meta_dfs[sheet_name]
             sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
-            #sheet_df.to_excel(
-            #    writer, sheet_name=sheet_name, index=False, header=True
-            #)
 
     catcherr_logger.info(
         f"Process Complete. The output file can be found here: {file_dir_path}/{catcherr_out_file}"

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -590,7 +590,7 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
                 reordered_df[i] = dataframe[i].tolist()
             else:
                 logger.warning(f"Column {i} in sheet {sheet_name} was left empty")
-        return reorder_dataframe
+        return reordered_df
 
     catcherr_logger.info("Writing out the CatchERR using pd.ExcelWriter")
     # save out template

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -569,8 +569,8 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
     #
     # Replace any NaN with "" before writing output
     #
-    ############## 
-                    
+    ##############
+
     for node in dict_nodes:
         df = meta_dfs[node]
         df = df.fillna("")
@@ -593,7 +593,10 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
         # for each sheet df
         for sheet_name in meta_dfs.keys():
             sheet_df = meta_dfs[sheet_name]
-            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
+            # sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
+            sheet_df.to_excel(
+                writer, sheet_name=sheet_name, index=False, header=True
+            )
 
     catcherr_logger.info(
         f"Process Complete. The output file can be found here: {file_dir_path}/{catcherr_out_file}"

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -593,10 +593,10 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
         # for each sheet df
         for sheet_name in meta_dfs.keys():
             sheet_df = meta_dfs[sheet_name]
-            # sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
-            sheet_df.to_excel(
-                writer, sheet_name=sheet_name, index=False, header=True
-            )
+            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
+            #sheet_df.to_excel(
+            #    writer, sheet_name=sheet_name, index=False, header=True
+            #)
 
     catcherr_logger.info(
         f"Process Complete. The output file can be found here: {file_dir_path}/{catcherr_out_file}"

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -593,7 +593,7 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
         # for each sheet df
         for sheet_name in meta_dfs.keys():
             sheet_df = meta_dfs[sheet_name]
-            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=True)
+            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
 
     catcherr_logger.info(
         f"Process Complete. The output file can be found here: {file_dir_path}/{catcherr_out_file}"

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -302,6 +302,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # file --> sample
     sample_file = pd.DataFrame()
+    print(f"df_file columns: \n {*df_file.columns.tolist(),}")
     if "sample" in ccdi_to_cds_nodes:
         if "sample_id" in df_file.columns:
             sample_file = join_node(ccdi_dfs["sample"], df_file, "sample_id")

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -745,8 +745,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
             df_join_all = df_join_all.drop("repository_of_synonym_id", axis=1)
 
         if "sample_id" in synonym_df.columns:
-            print("synonym_df columns:" + synonym_df.columns.tolist())
-            print("df_join_all columns:" + df_join_all.columns.tolist())
+            print(f"synonym_df columns: {*synonym_df.columns.tolist(),}" )
+            print(f"df_join_all columns: {*df_join_all.columns.tolist(),}")
             df_join_all = join_node(df_join_all, synonym_df, "sample_id")
             df_join_all = join_file_node_cleaner(df_join_all)
             # now we need to move sample_ids that are related to BioSample over to the property `dbGaP_subject_id`

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -193,6 +193,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # pull out df for study
     df_study_level = df_all
+    print("below is the df_all")
+    print(df_all)
 
     # add participant
     if "participant" in ccdi_to_cds_nodes:

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -287,13 +287,19 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
                 col_y = col_base + "_y"
                 node_df[col_base] = node_df[col_x].combine_first(node_df[col_y])
                 node_df.drop(columns=[col_x, col_y], inplace=True)
-
+        print(node_df)
         # clean up the data frame, drop empty columns, rows that don't have files, reset index and remove duplicates.
         if "file_url_in_cds" in node_df.columns:
             node_df = node_df.dropna(subset=["file_url_in_cds"])
-        node_df = node_df.dropna(axis=1, how="all")
-        node_df = node_df.reset_index(drop=True)
+        print("dropna of empty file_url_in_cds")
+        print(node_df)
+        node_df = node_df.dropna(axis=1, how="all").reset_index(drop=True)
+        print("dropna of all empty columns")
+        print(node_df)
+        #node_df = node_df.reset_index(drop=True)
         node_df = node_df.drop_duplicates()
+        print("drop duplicates")
+        print(node_df)
         return node_df
 
     # Do an empty check on the parent nodes before trying to join them
@@ -312,6 +318,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
             print(sample_file)
             sample_file = join_file_node_cleaner(sample_file)
             print("printing sample_file afer join_file_node_cleaner")
+            print(sample_file)
     print("printing final sample_file df")
     print(sample_file)
     # file --> pdx

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -259,7 +259,6 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     else:
         pass
 
-
     # START WITH FILES INSTEAD AND WALK EACH LINE BACK?
     # Based on each connection possible for the files walk it back manually by starting with the most likely connections
 
@@ -714,7 +713,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
         if not node_path.empty:
             df_join_all = pd.concat([df_join_all, node_path], axis=0)
 
-    #To reduce complexity in the conversion, only lines where the personnel type is PI will be used in the CDS template end file. Otherwise use Co-PI or just pass if nothing else or too complex.
+    # To reduce complexity in the conversion, only lines where the personnel type is PI will be used in the CDS template end file. Otherwise use Co-PI or just pass if nothing else or too complex.
     if 'PI' in df_join_all['personnel_type'].unique().tolist():
         df_join_all=df_join_all[df_join_all['personnel_type']=='PI']
     elif 'Co-PI' in df_join_all['personnel_type'].unique().tolist():
@@ -729,7 +728,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     if 'synonym' in ccdi_to_cds_nodes:
         synonym_df = ccdi_dfs["synonym"]
         synonym_df.rename(columns=col_remap, inplace=True)
-    
+
         if "participant_id" in synonym_df.columns:
             df_join_all = join_node(df_join_all, synonym_df, "participant_id")
             df_join_all = join_file_node_cleaner(df_join_all)
@@ -739,13 +738,15 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
                 df_join_all["dbGaP_subject_id"] = df_join_all.loc[
                     df_join_all["repository_of_synonym_id"] == "dbGaP", "synonym_id"
                 ]
-    
+
         if "synonym_id" in df_join_all.columns:
             df_join_all = df_join_all.drop("synonym_id", axis=1)
         if "repository_of_synonym_id" in df_join_all.columns:
             df_join_all = df_join_all.drop("repository_of_synonym_id", axis=1)
-    
+
         if "sample_id" in synonym_df.columns:
+            print("synonym_df columns:" + synonym_df.columns.tolist())
+            print("df_join_all columns:" + df_join_all.columns.tolist())
             df_join_all = join_node(df_join_all, synonym_df, "sample_id")
             df_join_all = join_file_node_cleaner(df_join_all)
             # now we need to move sample_ids that are related to BioSample over to the property `dbGaP_subject_id`
@@ -846,7 +847,6 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     else:
         cds_df["study_name"] = df_join_all["study_short_title"]
 
-    
     # if there is a number_of_participants value
     if "number_of_participants" in df_join_all.columns:
         # if there is a number_of_participants
@@ -941,7 +941,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
         cds_df["primary_diagnosis"] = df_join_all["diagnosis_icd_o"]
     elif "diagnosis_classification" in df_join_all.columns:
         cds_df['primary_diagnosis']=df_join_all['diagnosis_classification']
-        #further diagnosis handling for "see diagnosis_comment" copying
+        # further diagnosis handling for "see diagnosis_comment" copying
         if 'diagnosis_comment' in df_join_all.columns:
             comment_true = cds_df['primary_diagnosis'] == "see diagnosis_comment"
             cds_df.loc[comment_true, 'primary_diagnosis'] = df_join_all.loc[comment_true, 'diagnosis_comment']

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -303,6 +303,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     # file --> sample
     sample_file = pd.DataFrame()
     print(f"df_file columns: \n {*df_file.columns.tolist(),}")
+    print(f"ccdi_dfs[sample]")
+    print(ccdi_dfs["sample"])
     if "sample" in ccdi_to_cds_nodes:
         if "sample_id" in df_file.columns:
             sample_file = join_node(ccdi_dfs["sample"], df_file, "sample_id")

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -143,6 +143,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # This was removed as the nodes required for CDS destroys paths that need to be walked to obtain the full data.
     ccdi_to_cds_nodes = [node for node in ccdi_nodes if node not in nodes_removed]
+    print(f"{*ccdi_to_cds_nodes,}")
 
     ### MERGING OF ALL DATA
     # The variable names will be the initials of the node as they are added
@@ -305,7 +306,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
         if "sample_id" in df_file.columns:
             sample_file = join_node(ccdi_dfs["sample"], df_file, "sample_id")
             sample_file = join_file_node_cleaner(sample_file)
-
+    print("printing sample_file df")
+    print(sample_file)
     # file --> pdx
     pdx_file = pd.DataFrame()
     if "pdx" in ccdi_to_cds_nodes:

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -711,7 +711,10 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     for node_path in all_paths:
         if not node_path.empty:
-            df_join_all = pd.concat([df_join_all, node_path], axis=0)
+            df_join_all = pd.concat([df_join_all, node_path], axis=0).reset_index(drop=True)
+        else:
+            print(node_path)
+            print("is empty")
 
     # To reduce complexity in the conversion, only lines where the personnel type is PI will be used in the CDS template end file. Otherwise use Co-PI or just pass if nothing else or too complex.
     if 'PI' in df_join_all['personnel_type'].unique().tolist():

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -143,7 +143,6 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # This was removed as the nodes required for CDS destroys paths that need to be walked to obtain the full data.
     ccdi_to_cds_nodes = [node for node in ccdi_nodes if node not in nodes_removed]
-    print(f"{*ccdi_to_cds_nodes,}")
 
     ### MERGING OF ALL DATA
     # The variable names will be the initials of the node as they are added
@@ -194,8 +193,6 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # pull out df for study
     df_study_level = df_all
-    print("below is the df_all")
-    print(df_all)
 
     # add participant
     if "participant" in ccdi_to_cds_nodes:
@@ -287,20 +284,12 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
                 col_y = col_base + "_y"
                 node_df[col_base] = node_df[col_x].combine_first(node_df[col_y])
                 node_df.drop(columns=[col_x, col_y], inplace=True)
-        print(node_df)
         # clean up the data frame, drop empty columns, rows that don't have files, reset index and remove duplicates.
         if "file_url_in_cds" in node_df.columns:
-            print(node_df["file_url_in_cds"])
             node_df = node_df.dropna(subset=["file_url_in_cds"])
-        print("dropna of empty file_url_in_cds")
-        print(node_df)
         node_df = node_df.dropna(axis=1, how="all").reset_index(drop=True)
-        print("dropna of all empty columns")
-        print(node_df)
         #node_df = node_df.reset_index(drop=True)
         node_df = node_df.drop_duplicates()
-        print("drop duplicates")
-        print(node_df)
         return node_df
 
     # Do an empty check on the parent nodes before trying to join them
@@ -309,19 +298,10 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # file --> sample
     sample_file = pd.DataFrame()
-    print(f"df_file columns: \n {*df_file.columns.tolist(),}")
-    print(f"ccdi_dfs[sample]")
-    print(ccdi_dfs["sample"])
     if "sample" in ccdi_to_cds_nodes:
         if "sample_id" in df_file.columns:
             sample_file = join_node(ccdi_dfs["sample"], df_file, "sample_id")
-            print("printing sample_file after join_node")
-            print(sample_file)
             sample_file = join_file_node_cleaner(sample_file)
-            print("printing sample_file afer join_file_node_cleaner")
-            print(sample_file)
-    print("printing final sample_file df")
-    print(sample_file)
     # file --> pdx
     pdx_file = pd.DataFrame()
     if "pdx" in ccdi_to_cds_nodes:
@@ -730,10 +710,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     for node_path in all_paths:
         if not node_path.empty:
             df_join_all = pd.concat([df_join_all, node_path], axis=0, ignore_index=True)
-            print(node_path)
         else:
-            print(node_path)
-            print("is empty")
+            pass
 
     # To reduce complexity in the conversion, only lines where the personnel type is PI will be used in the CDS template end file. Otherwise use Co-PI or just pass if nothing else or too complex.
     if 'PI' in df_join_all['personnel_type'].unique().tolist():
@@ -767,8 +745,6 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
             df_join_all = df_join_all.drop("repository_of_synonym_id", axis=1)
 
         if "sample_id" in synonym_df.columns:
-            print(f"synonym_df columns: {*synonym_df.columns.tolist(),}" )
-            print(f"df_join_all columns: {*df_join_all.columns.tolist(),}")
             df_join_all = join_node(df_join_all, synonym_df, "sample_id")
             df_join_all = join_file_node_cleaner(df_join_all)
             # now we need to move sample_ids that are related to BioSample over to the property `dbGaP_subject_id`

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -711,7 +711,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     for node_path in all_paths:
         if not node_path.empty:
-            df_join_all = pd.concat([df_join_all, node_path], axis=0).reset_index(drop=True)
+            df_join_all = pd.concat([df_join_all, node_path], axis=0, ignore_index=True)
+            print(node_path)
         else:
             print(node_path)
             print("is empty")

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -308,8 +308,11 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     if "sample" in ccdi_to_cds_nodes:
         if "sample_id" in df_file.columns:
             sample_file = join_node(ccdi_dfs["sample"], df_file, "sample_id")
+            print("printing sample_file after join_node")
+            print(sample_file)
             sample_file = join_file_node_cleaner(sample_file)
-    print("printing sample_file df")
+            print("printing sample_file afer join_file_node_cleaner")
+    print("printing final sample_file df")
     print(sample_file)
     # file --> pdx
     pdx_file = pd.DataFrame()

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -290,6 +290,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
         print(node_df)
         # clean up the data frame, drop empty columns, rows that don't have files, reset index and remove duplicates.
         if "file_url_in_cds" in node_df.columns:
+            print(node_df["file_url_in_cds"])
             node_df = node_df.dropna(subset=["file_url_in_cds"])
         print("dropna of empty file_url_in_cds")
         print(node_df)

--- a/src/template_exampler.py
+++ b/src/template_exampler.py
@@ -442,6 +442,6 @@ def make_template_example(manifest_path: str, entry_num: int) -> tuple:
         # for each sheet df
         for sheet_name in populated_dfs.keys():
             sheet_df = populated_dfs[sheet_name]
-            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=True)
+            sheet_df.to_excel(writer, sheet_name=sheet_name, index=False, header=False, startrow=1)
 
     return output_path, logger_filename

--- a/src/update_ccdi_template.py
+++ b/src/update_ccdi_template.py
@@ -296,7 +296,7 @@ def updateManifest(manifest: str, template: str, template_version: str) -> Tuple
         for key in populated_template_dict.keys():
             logger.info(f"Writing sheet {key} to output")
             key_df = populated_template_dict[key]
-            key_df.to_excel(writer, sheet_name=key, index=False, header=True)
+            key_df.to_excel(writer, sheet_name=key, index=False, header=False, startrow=1)
     logger.info(f"Updated manifest can be found at: {output_name}")
 
     return output_name, output_logger


### PR DESCRIPTION
Quick Fix

- Maintain the `header style` when re-writing dataframe to excel sheet
- Affected codes: s3_catcherry.py, template_exampler.py, update_ccdi_template.py