### PR TITLE
allows workflow to conitnue without latest template version info

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -132,7 +132,10 @@ class CCDI_Tags(Task):
 def get_ccdi_latest_release() -> str:
     latest_url = GithubAPTendpoint.ccdi_model_recent_release
     response = requests.get(latest_url)
-    tag_name = response.json()["tag_name"]
+    if "tag_name" in response.json().keys():
+        tag_name = response.json()["tag_name"]
+    else:
+        tag_name = "unknown"
     return tag_name
 
 
@@ -144,6 +147,7 @@ def dl_sra_template() -> None:
     f.write(r.content)
     return sra_filename
 
+
 @task
 def dl_file_from_url(file_endpoint: str) -> str:
     filename = os.path.basename(file_endpoint)
@@ -151,6 +155,7 @@ def dl_file_from_url(file_endpoint: str) -> str:
     f = open(filename, "wb")
     f.write(r.content)
     return filename
+
 
 @task
 def check_ccdi_version(ccdi_manifest: str) -> str:
@@ -412,9 +417,11 @@ def view_all_s3_objects(source_bucket):
 
 
 def identify_data_curation_log_file(start_str: str):
-    file_list =  os.listdir("./")
+    file_list = os.listdir("./")
     log_file_regx = start_str + r"[0-9]{4}-[0-9]{2}-[0-9]{2}"
-    log_file_found = [i for i in file_list if re.search(log_file_regx, i) and ".log" in i]
+    log_file_found = [
+        i for i in file_list if re.search(log_file_regx, i) and ".log" in i
+    ]
     if len(log_file_found) == 0:
         return None
     else:
@@ -493,7 +500,13 @@ def markdown_template_updater(
 
 @task
 def markdown_input_task(
-    source_bucket: str, runner: str, manifest: str, template: str, sra_template: str, sra_pre_sub: str, dbgap_pre_sub: str
+    source_bucket: str,
+    runner: str,
+    manifest: str,
+    template: str,
+    sra_template: str,
+    sra_pre_sub: str,
+    dbgap_pre_sub: str,
 ):
     """Creates markdown artifacts of workflow inputs using Prefect
     create_markdown_artifact()
@@ -929,8 +942,10 @@ class CheckCCDI:
         return term_dict
 
     def find_file_nodes(self):
-        dict_df =  self.get_dict_df()
-        file_node_list = dict_df[dict_df["Property"] == "file_url_in_cds"]["Node"].tolist()
+        dict_df = self.get_dict_df()
+        file_node_list = dict_df[dict_df["Property"] == "file_url_in_cds"][
+            "Node"
+        ].tolist()
         # remove any duplcates
         file_node_list_uniq = list(set(file_node_list))
         return file_node_list_uniq

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
-from src.utils import CCDI_Tags
+from src.utils import CCDI_Tags, get_ccdi_latest_release
 
 
 # test for CCDI_Tags class
@@ -93,3 +93,19 @@ def test_CCDI_Tags_get_tag_element(
     request_return.json.return_value = fake_tags_api_return
     tag_element = my_ccdi_tags.get_tag_element(tag="0.1.0")
     assert tag_element["zipball_url"] == "http://url/tags/0.1.0"
+
+
+@mock.patch("src.utils.requests", autospec=True)
+def test_get_ccdi_latest_release_valid(mock_requests):
+    request_return = mock_requests.get.return_value
+    request_return.json.return_value = {"tag_name": "1.8.2"}
+    latest_release = get_ccdi_latest_release()
+    assert latest_release == "1.8.2"
+
+
+@mock.patch("src.utils.requests", autospec=True)
+def test_get_ccdi_latest_release_invalid(mock_requests):
+    request_return = mock_requests.get.return_value
+    request_return.json.return_value = {"message": "failed api call"}
+    latest_release = get_ccdi_latest_release()
+    assert latest_release == "unknown"

--- a/workflows/s3-Prefect-Pipeline.py
+++ b/workflows/s3-Prefect-Pipeline.py
@@ -99,18 +99,23 @@ def runner(
         else:
             pass
     else:
-        if manifest_version == template_version:
-            output_folder = output_folder + "(OLD_VERSION_v" + manifest_version + ")"
-            runner_logger.error(
-                f"An old version(v{manifest_version}) of CCDI manifest and CCDI template were provided. New version of CCDI template v{latest_manifest_version} is available"
-            )
+        if latest_manifest_version == "unknown":
+            # This might happen when the github API limit being reached and we failed to get latest manifest version
+            # the get_ccdi_latest_release() will return "unknown"
+            runner_logger.error("Fail to retrieve latest manifest version through GitHub API likely due to API rate limit being reached. The workflow will continue without this information")
         else:
-            runner_logger.error(
-                f"An old version of CCDI manifest was provided(v{manifest_version}). And no matching CCDI template was provided. Please provide a matching CCDI template in the same version of the manifest or update the CCDI manifest to the latest version v{latest_manifest_version}"
-            )
-            raise ValueError(
-                "CCDI manifest version is older version and doesn't match to the version of provided CCDI template"
-            )
+            if manifest_version == template_version:
+                output_folder = output_folder + "(OLD_VERSION_v" + manifest_version + ")"
+                runner_logger.error(
+                    f"An old version(v{manifest_version}) of CCDI manifest and CCDI template were provided. New version of CCDI template v{latest_manifest_version} is available"
+                )
+            else:
+                runner_logger.error(
+                    f"An old version of CCDI manifest was provided(v{manifest_version}). And no matching CCDI template was provided. Please provide a matching CCDI template in the same version of the manifest or update the CCDI manifest to the latest version v{latest_manifest_version}"
+                )
+                raise ValueError(
+                    "CCDI manifest version is older version and doesn't match to the version of provided CCDI template"
+                )
 
     # download SRA template if not provided
     if sra_template_path != "path_to/sra_template/in/s3/bucket":
@@ -221,7 +226,7 @@ def runner(
             wf_step="ValidationRy",
             sub_folder="2_ValidationRy_output",
         )
-        
+
         # run CCDI to SRA
         runner_logger.info("Running CCDI to SRA submission file flow")
         try:
@@ -245,7 +250,6 @@ def runner(
             wf_step="CCDI-to-SRA",
             sub_folder="3_SRA_submisison_output",
         )
-
 
         # run CCDI to dbGaP
         runner_logger.info("Running CCDI to dbGaP submission file flow")


### PR DESCRIPTION
- Allows `ccdi-data-curation` workflow to continue even when github api fails due to api rate limit reached