### PR TITLE
CCDIDC-914 Make github API call with token headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ et-xmlfile==1.1.0
 exceptiongroup==1.2.0
 fsspec==2023.10.0
 google-auth==2.23.4
+graphql-core==3.2.3
 graphviz==0.20.1
 greenlet==3.0.1
 griffe==0.38.0
@@ -42,7 +43,9 @@ humanize==4.9.0
 hyperframe==6.0.1
 idna==3.6
 importlib-metadata==6.8.0
+importlib_resources==6.1.3
 iniconfig==2.0.0
+itsdangerous==2.1.2
 Jinja2==3.1.2
 jmespath==1.0.1
 jsonpatch==1.33
@@ -57,6 +60,8 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.3
 mdurl==0.1.2
 mock==5.1.0
+mypy-boto3-s3==1.34.14
+mypy-boto3-secretsmanager==1.34.43
 neo4j==5.17.0
 numpy==1.26.2
 oauthlib==3.2.2
@@ -67,7 +72,10 @@ pandas==2.1.3
 pathspec==0.11.2
 pendulum==2.1.2
 pluggy==1.3.0
-prefect==2.14.8
+prefect==2.14.19
+prefect-aws==0.4.11
+prefect-docker==0.4.5
+prefect-github==0.2.2
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
@@ -76,6 +84,7 @@ pydantic_core==2.14.5
 Pygments==2.17.2
 pytest==7.4.4
 python-dateutil==2.8.2
+python-multipart==0.0.9
 python-slugify==8.0.1
 pytz==2023.3.post1
 pytzdata==2020.1
@@ -85,6 +94,7 @@ referencing==0.31.0
 regex==2023.10.3
 requests==2.31.0
 requests-oauthlib==1.3.1
+rfc3339-validator==0.1.4
 rich==13.7.0
 rpds-py==0.13.1
 rsa==4.7.2
@@ -92,11 +102,13 @@ ruamel.yaml==0.18.5
 ruamel.yaml.clib==0.2.8
 s3-tree==0.1.0
 s3transfer==0.8.1
+sgqlc==16.3
 six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==2.0.23
 starlette==0.32.0.post1
 tabulate==0.9.0
+tenacity==8.2.3
 text-unidecode==1.3
 toml==0.10.2
 tomli==2.0.1

--- a/src/create_submission.py
+++ b/src/create_submission.py
@@ -12,6 +12,7 @@ from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl import Workbook
 from typing import Any, TypeVar, Dict, List
 from openpyxl.styles import PatternFill, Font
+from src.utils import get_github_token
 
 
 DataFrame = TypeVar("DataFrame")
@@ -459,7 +460,9 @@ class ManifestSheet():
 
     def release_api_return(self) -> List[Dict]:
         """Get a return from github repo ccdi-model release api"""
-        release_endpoint_response = requests.get(self.release_api)
+        github_token =  get_github_token()
+        headers = {"Authorization": "token " + github_token}
+        release_endpoint_response = requests.get(self.release_api, headers=headers)
         response_list = release_endpoint_response.json()
         version_list = []
         title_list = []

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -4,7 +4,7 @@ import openpyxl
 from datetime import date
 import warnings
 from openpyxl.utils.dataframe import dataframe_to_rows
-from src.utils import get_logger, get_date, get_time
+from src.utils import get_logger, get_date, get_time, get_github_token
 from prefect import flow
 import requests
 import re
@@ -26,7 +26,9 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     cds_template_url = (
         "https://api.github.com/repos/CBIIT/cds-model/contents/metadata-manifest/"
     )
-    cds_template_content = requests.get(cds_template_url).json()
+    github_token = get_github_token()
+    headers = {"Authorization": "token " + github_token}
+    cds_template_content = requests.get(cds_template_url, headers=headers).json()
     if re.search(
         "v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.xlsx$",
         cds_template_content[0]["name"],
@@ -288,7 +290,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
         if "file_url_in_cds" in node_df.columns:
             node_df = node_df.dropna(subset=["file_url_in_cds"])
         node_df = node_df.dropna(axis=1, how="all").reset_index(drop=True)
-        #node_df = node_df.reset_index(drop=True)
+        # node_df = node_df.reset_index(drop=True)
         node_df = node_df.drop_duplicates()
         return node_df
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -956,5 +956,10 @@ class CheckCCDI:
 def get_github_credentials()-> None:
     runner_logger = get_run_logger()
     github_credentials_block = GitHubCredentials.load("fnlccdidatacuration")
-    runner_logger.info("credential block: " + github_credentials_block.token)
+    token_value = github_credentials_block.token.get_secret_value()
+    runner_logger.info("credential block: " + token_value)
+    headers = {"Authorization": "token " + token_value}
+    # try to get api return
+    response = requests.get(GithubAPTendpoint.ccdi_model_recent_release, headers=headers)
+    runner_logger.info(response.json())
     return None

--- a/src/utils.py
+++ b/src/utils.py
@@ -961,5 +961,5 @@ def get_github_credentials()-> None:
     headers = {"Authorization": "token " + token_value}
     # try to get api return
     response = requests.get(GithubAPTendpoint.ccdi_model_recent_release, headers=headers)
-    runner_logger.info(response.json())
+    runner_logger.info(json.dumps(response.json(), indent=4))
     return None

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,4 @@
-from prefect import flow, task, Task
+from prefect import flow, task, Task, get_run_logger
 from prefect.artifacts import create_markdown_artifact
 from dataclasses import dataclass, field
 from typing import List, TypeVar, Dict, Tuple
@@ -954,6 +954,7 @@ class CheckCCDI:
 
 @flow(log_prints=True)
 def get_github_credentials()-> None:
+    runner_logger = get_run_logger()
     github_credentials_block = GitHubCredentials.load("fnlccdidatacuration")
-    print(github_credentials_block.token)
+    runner_logger.info("credential block: " + github_credentials_block.token)
     return None

--- a/src/utils.py
+++ b/src/utils.py
@@ -21,6 +21,7 @@ from zipfile import ZipFile
 from shutil import copy
 import json
 from botocore.exceptions import ClientError
+from prefect_github import GitHubCredentials
 
 
 ExcelFile = TypeVar("ExcelFile")
@@ -949,3 +950,10 @@ class CheckCCDI:
         # remove any duplcates
         file_node_list_uniq = list(set(file_node_list))
         return file_node_list_uniq
+
+
+@flow(log_prints=True)
+def get_github_credentials()-> None:
+    github_credentials_block = GitHubCredentials.load("fnlccdidatacuration")
+    print(github_credentials_block.token)
+    return None

--- a/src/utils.py
+++ b/src/utils.py
@@ -53,7 +53,9 @@ class CCDI_Tags(Task):
         self.tags_api = "https://api.github.com/repos/CBIIT/ccdi-model/tags"
 
     def get_tags(self) -> List[Dict]:
-        api_re = requests.get(self.tags_api)
+        github_token =  get_github_token()
+        headers = {"Authorization": "token " + github_token}
+        api_re = requests.get(self.tags_api, headers=headers)
         tags_list = api_re.json()
         return tags_list
 
@@ -132,7 +134,9 @@ class CCDI_Tags(Task):
 
 def get_ccdi_latest_release() -> str:
     latest_url = GithubAPTendpoint.ccdi_model_recent_release
-    response = requests.get(latest_url)
+    github_token =  get_github_token()
+    headers = {"Authorization": "token " + github_token}
+    response = requests.get(latest_url, headers=headers)
     if "tag_name" in response.json().keys():
         tag_name = response.json()["tag_name"]
     else:
@@ -143,7 +147,9 @@ def get_ccdi_latest_release() -> str:
 @task
 def dl_sra_template() -> None:
     sra_filename = "phsXXXXXX.xlsx"
-    r = requests.get(GithubAPTendpoint.sra_template)
+    github_token = get_github_token()
+    headers = {"Authorization": "token " + github_token}
+    r = requests.get(GithubAPTendpoint.sra_template, headers=headers)
     f = open(sra_filename, "wb")
     f.write(r.content)
     return sra_filename
@@ -174,7 +180,9 @@ def check_ccdi_version(ccdi_manifest: str) -> str:
 @task(log_prints=True)
 def dl_ccdi_template() -> None:
     """Downloads the latest version of CCDI manifest"""
-    manifest_page_response = requests.get(GithubAPTendpoint.ccdi_model_manifest)
+    github_token = get_github_token()
+    headers = {"Authorization": "token " + github_token}
+    manifest_page_response = requests.get(GithubAPTendpoint.ccdi_model_manifest, headers=headers)
     manifest_dict_list = manifest_page_response.json()
     if not isinstance(manifest_dict_list, list):
         print("Github API return was not a list: " + str(manifest_dict_list))
@@ -191,8 +199,8 @@ def dl_ccdi_template() -> None:
         and re.search(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.xlsx$", i)
     ]
     manifest_response = [j for j in manifest_dict_list if j["name"] == manifest[0]]
-    manifest_dl_url = requests.get(manifest_response[0]["url"]).json()["download_url"]
-    manifest_dl_res = requests.get(manifest_dl_url)
+    manifest_dl_url = requests.get(manifest_response[0]["url"], headers=headers).json()["download_url"]
+    manifest_dl_res = requests.get(manifest_dl_url, headers=headers)
     manifest_file = open(manifest[0], "wb")
     manifest_file.write(manifest_dl_res.content)
     return manifest[0]
@@ -957,9 +965,13 @@ def get_github_credentials()-> None:
     runner_logger = get_run_logger()
     github_credentials_block = GitHubCredentials.load("fnlccdidatacuration")
     token_value = github_credentials_block.token.get_secret_value()
-    runner_logger.info("credential block: " + token_value)
     headers = {"Authorization": "token " + token_value}
     # try to get api return
     response = requests.get(GithubAPTendpoint.ccdi_model_recent_release, headers=headers)
     runner_logger.info(json.dumps(response.json(), indent=4))
     return None
+
+def get_github_token() -> str:
+    github_credentials_block = GitHubCredentials.load("fnlccdidatacuration")
+    token_value = github_credentials_block.token.get_secret_value()
+    return token_value


### PR DESCRIPTION
Added patch

- Make github api calls with headers info including a credential token
- Changes made to workflows: `ccdi-data-curation`, `model-to-submission`