### PR TITLE
Ccdidc 886 file remover

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -171,7 +171,7 @@ deployments:
 
     # flow-specific parameters
     parameters:
-      bucket: "ccdi-validation"
+      bucket_name: "ccdi-validation"
       list_keys:
         - "sub_dir1/subdir2/object_file.txt"
         - "sub_dir3/object_file.tsv"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -161,3 +161,34 @@ deployments:
       name: ccdi-curation-ecs
       work_queue_name: null
       job_variables: {}
+
+  - name: TEST-md5sum-function
+    version: null
+    tags: ["Test"]
+    description: null
+    entrypoint: src/file_remover.py:objects_md5sum
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+      list_keys:
+        - "sub_dir1/subdir2/object_file.txt"
+        - "sub_dir3/object_file.tsv"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.projects.steps.git_clone_project:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: CCDIDC-886_file_remover
+      - prefect.projects.steps.pip_install_requirements:
+          requirements_file: requirements.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-curation-ecs
+      work_queue_name: null
+      job_variables: {}

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -192,3 +192,36 @@ deployments:
       name: ccdi-curation-ecs
       work_queue_name: null
       job_variables: {}
+
+  - name: TEST-construct-staging-keys
+    version: null
+    tags: ["Test"]
+    description: null
+    entrypoint: src/file_remover.py:objects_staging_key
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      object_prod_key_list:
+        - "release_folder/sub_dir1/sub_dir2/object_file.txt"
+        - "release_folder/sub_dir3/object_file.tsv"
+        - "release_folder/sub_dir4/sub_dir5/sub_dir6/object_file.fastq"
+      prod_bucket_path: "prod_bucket/release_folder"
+      staging_bucket_path: "staging_bucket/staging_subfolder"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.projects.steps.git_clone_project:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: CCDIDC-886_file_remover
+      - prefect.projects.steps.pip_install_requirements:
+          requirements_file: requirements.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-curation-ecs
+      work_queue_name: null
+      job_variables: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,9 @@ humanize==4.9.0
 hyperframe==6.0.1
 idna==3.6
 importlib-metadata==6.8.0
+importlib_resources==6.1.3
 iniconfig==2.0.0
+itsdangerous==2.1.2
 Jinja2==3.1.2
 jmespath==1.0.1
 jsonpatch==1.33
@@ -57,6 +59,9 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.3
 mdurl==0.1.2
 mock==5.1.0
+mypy-boto3-s3==1.34.14
+mypy-boto3-secretsmanager==1.34.43
+neo4j==5.17.0
 numpy==1.26.2
 oauthlib==3.2.2
 openpyxl==3.1.2
@@ -66,7 +71,9 @@ pandas==2.1.3
 pathspec==0.11.2
 pendulum==2.1.2
 pluggy==1.3.0
-prefect==2.14.8
+prefect==2.16.4
+prefect-aws==0.4.11
+prefect-docker==0.4.5
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
@@ -75,6 +82,7 @@ pydantic_core==2.14.5
 Pygments==2.17.2
 pytest==7.4.4
 python-dateutil==2.8.2
+python-multipart==0.0.9
 python-slugify==8.0.1
 pytz==2023.3.post1
 pytzdata==2020.1
@@ -84,6 +92,7 @@ referencing==0.31.0
 regex==2023.10.3
 requests==2.31.0
 requests-oauthlib==1.3.1
+rfc3339-validator==0.1.4
 rich==13.7.0
 rpds-py==0.13.1
 rsa==4.7.2
@@ -96,6 +105,7 @@ sniffio==1.3.0
 SQLAlchemy==2.0.23
 starlette==0.32.0.post1
 tabulate==0.9.0
+tenacity==8.2.3
 text-unidecode==1.3
 toml==0.10.2
 tomli==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ pandas==2.1.3
 pathspec==0.11.2
 pendulum==2.1.2
 pluggy==1.3.0
-prefect==2.16.4
+prefect==2.14.19
 prefect-aws==0.4.11
 prefect-docker==0.4.5
 pyasn1==0.5.1

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -12,6 +12,12 @@ from prefect import flow
 
 
 def parse_file_url_in_cds(url: str) -> tuple:
+    """Parse an s3 uri into bucket name and key"""
+    # add s3:// if missing
+    if not url.startswith("s3://"):
+        url = "s3://" + url
+    else:
+        pass
     parsed_url = urlparse(url)
     bucket_name = parsed_url.netloc
     object_key = parsed_url.path

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -376,10 +376,10 @@ def find_missing_objects(
 
 @flow
 def create_matching_object_manifest(
-    prod_bucket_path: str, staging_bucket_path: str, runner: str
+    prod_bucket_path: str, staging_bucket_path: str
 ) -> None:
     # get output name
-    output_manifest_name = runner + "_matching_objects_manifest_" + get_time() + ".tsv"
+    output_manifest_name = "matching_objects_manifest_" + get_time() + ".tsv"
 
     # create logger
     logger = get_run_logger()
@@ -593,7 +593,7 @@ def create_matching_object_manifest(
 
 
 @flow
-def objects_deletion(manifest_file_path: str, delete_column_name: str, runner: str):
+def objects_deletion(manifest_file_path: str, delete_column_name: str):
     logger = get_run_logger()
 
     # read manifest file

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -38,7 +38,7 @@ def parse_bucket_folder_path(bucket_folder_path:str) -> tuple:
         folder_path = ""
     return bucket, folder_path
 
-def construct_staging_key(object_prod_bucket_key: str, prod_bucket_path: str, staging_bucket_path: str) -> str:
+def construct_staging_bucket_key(object_prod_bucket_key: str, prod_bucket_path: str, staging_bucket_path: str) -> str:
     """Reconstruct the object key in staging bucket
 
     Example:
@@ -83,15 +83,24 @@ def get_md5sum(object_key: str, bucket: str) -> str:
     return md5_hash.hexdigest()
 
 @flow
-def objects_md5sum(list_keys: list[str], bucket_name: str):
+def objects_md5sum(list_keys: list[str], bucket_name: str) -> list[str]:
     """Get a list of md5sum using a list of keys and static bucket name
 
     Example: 
         list_keys = ["folder1/folder2/file1.txt","folder1/folder2/file2.txt","folder1/folder2/file3.txt"]
         bucket_name = "ccdi-staging"
     """
-    logger = get_run_logger()
+    #logger = get_run_logger()
     md5sum_futures = get_md5sum.map(list_keys, bucket_name)
     md5sum_list = [i.result() for i in md5sum_futures]
-    logger.info(f"md5sum list return is: {*md5sum_list,}")
+    #logger.info(f"md5sum list return is: {*md5sum_list,}")
     return md5sum_list
+
+@flow
+def objects_staging_key(object_prod_key_list: list[str], prod_bucket_path: str, staging_bucket_path: str) -> list[str]:
+    logger = get_run_logger()
+    staging_keys_future =  construct_staging_bucket_key.map(object_prod_key_list, prod_bucket_path, staging_bucket_path)
+    staging_keys_list = [i.result() for i in staging_keys_future]
+    for h in staging_keys_list:
+        logger.info(f"staging bucket: {h[0]}\nobject key: {h[1]}")
+    return staging_keys_list

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -324,8 +324,7 @@ def find_missing_objects(
 
     # find nonexist files, df has four columns "Key","Size", "md5sum","Filename", "Missing_Object_Candidate_Keys"
     not_found_df = manifest_df.loc[manifest_df["Staging_If_Exist"]==False, ["Key", "Size", "md5sum"]]
-    print(not_found_df)
-    not_found_df = not_found_df.assign(Filename = lambda x: (os.path.basename(x["Key"])))
+    not_found_df = not_found_df.assign(Filename = lambda x: (os.path.basename(x["Key"].values[0])))
     print(not_found_df)
 
     # add file basename to file_object_list

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -589,7 +589,7 @@ def objects_deletion(manifest_file_path: str, delete_column_name: str, runner: s
     logger.info(f"Deleted files: {success_count}/{len(delete_status)}")
 
     # prepare for file deletion output
-    delete_output = runner + "_deleting_object_summary_" + get_time() + ".tsv"
+    delete_output = "objects_deletion_summary_" + get_time() + ".tsv"
     logger.info(f"Writing objects deletion summary table to: {delete_output}")
     delete_dict = {"s3_uri": delete_uri_list, "delete_status" : delete_status}
     delete_df = pd.DataFrame(delete_dict)

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -53,9 +53,9 @@ Do you have a manifest of s3 URI endpoints to be deleted :
         """
 **Please provide inputs as shown below**
 
-- **bucket**: bucket name of where the manifest lives
-- **manifest_tsv_path**: path of the manifest(tsv) in the bucket
-- **delete_column_name**: column name of s3 uri to be deleted
+- **bucket**: bucket name of where the manifest lives (e.g., ccdi-validation)
+- **manifest_tsv_path**: path of the manifest(tsv) in the bucket (e.g., folder/manifest.tsv)
+- **delete_column_name**: column name of s3 uri to be deleted (e.g., Staging_S3_URI)
 - **runner**: your runner id
 
 """
@@ -64,9 +64,9 @@ Do you have a manifest of s3 URI endpoints to be deleted :
         """
 **Please provide inputs as shown below**
 
-- **prod_bucket_path**: bucket path containing files you would like to keep
-- **staging_bucket_path**: bucket path containing duplicated objects under prod bucket path that you would like to delete
-- **workflow_output_bucket**: the bucket where the workflow output will be uploaded to
+- **prod_bucket_path**: bucket path containing files you would like to keep (e.g., prod-bucket/example_subfolder)
+- **staging_bucket_path**: bucket path containing duplicated objects under prod bucket path that you would like to delete (e.g., staging-bucket/example_subfolder)
+- **workflow_output_bucket**: the bucket where the workflow output will be uploaded to (e.g., ccdi-validation)
 - **runner**: your runner id
 
 """
@@ -77,7 +77,7 @@ Do you have a manifest of s3 URI endpoints to be deleted :
 
 !!CAUTION!!
 
-Make sure you have reviewed the manifest {manifest_file} under bucker {bucket} folder {folder}
+Make sure you have reviewed the manifest {manifest_file} under bucket {bucket} folder {folder}
 
 - **proceed_to_delete**: y/n
 
@@ -325,7 +325,7 @@ def find_missing_objects(
     # find nonexist files, df has four columns "Key","Size", "md5sum","Filename", "Missing_Object_Candidate_Keys"
     not_found_df = manifest_df.loc[manifest_df["Staging_If_Exist"]==False, ["Key", "Size", "md5sum"]]
     not_found_df["Filename"] = [os.path.basename(i) for i in not_found_df["Key"].tolist()]
-    print(not_found_df)
+    #print(not_found_df)
 
     # add file basename to file_object_list
     # "Bucket", "Key", "Size", "Filename"

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -41,7 +41,7 @@ class InputDescriptionMD:
     """dataclass for wait for input description MD"""
     have_manifest_md: str = (
         """
-**Welcome to the File Remover Flow!**
+**Welcome to the File Remover Workflow!**
 Today's Date: *{current_time}*
 
 Do you have a manifest containing **s3 URI endpoints** to be deleted :
@@ -55,7 +55,7 @@ Do you have a manifest containing **s3 URI endpoints** to be deleted :
 
 - **bucket**: bucket name of where the manifest lives (e.g., ccdi-validation)
 - **manifest_tsv_path**: path of the manifest(tsv) in the bucket (e.g., folder/manifest.tsv)
-- **delete_column_name**: column name of s3 uri to be deleted (e.g., Staging_S3_URI)
+- **delete_column_name**: column name of s3 URI to be deleted. S3 URI starts with s3://
 - **runner**: your runner id
 
 """
@@ -64,8 +64,8 @@ Do you have a manifest containing **s3 URI endpoints** to be deleted :
         """
 **Please provide inputs as shown below**
 
-- **prod_bucket_path**: bucket path containing files you would like to keep (e.g., prod-bucket/example_subfolder)
-- **staging_bucket_path**: bucket path containing duplicated objects under prod bucket path that you would like to delete (e.g., staging-bucket/example_subfolder)
+- **prod_bucket_path**: a bucket path containing files you would like to keep (e.g., prod-bucket/example_subfolder)
+- **staging_bucket_path**: a bucket path containing duplicated objects that you would like to delete (e.g., staging-bucket/example_subfolder)
 - **workflow_output_bucket**: the bucket where the workflow output will be uploaded to (e.g., ccdi-validation)
 - **runner**: your runner id
 

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -265,12 +265,16 @@ def delete_single_object_by_uri(object_uri: str, s3_client, logger) -> str:
     """Delete a single s3 uri"""
     bucket_name, object_key = parse_file_url_in_cds(url=object_uri)
     try:
-        s3_client.delete_object(Bucket=bucket_name, Key=object_key)
-        delete_status = "Success"
+        s3_client.head_object(Bucket=bucket_name, Key=object_key)
+        try:
+            s3_client.delete_object(Bucket=bucket_name, Key=object_key)
+            delete_status = "Success"
+        except ClientError as err:
+            logger.info(f"Fail to delete object {object_uri}: {err}")
+            delete_status = repr(err)
     except ClientError as err:
-        logger.info(f"Fail to delete object {object_uri}: {err}")
-        # delete_status = "Fail"
-        delete_status = repr(err)
+        logger.info(f"Object {object_uri} does not exist")
+        delete_status = "Not Found"
     return delete_status
 
 

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -1,0 +1,96 @@
+from prefect import flow, task
+from src.utils import set_s3_session_client
+from botocore.errorfactory import ClientError
+import os
+import hashlib
+
+def if_object_exists(bucket: str, key_path: str, logger) -> None:
+    """Retrives the metadata of an object without returning the
+    object itself
+
+    To use HEAD, you must have the s3:GetObject permission
+    """
+    s3_client= set_s3_session_client()
+    try:
+        object_meta = s3_client.head_object(Bucket=bucket,Key=key_path)
+        if_exist = True
+    except ClientError as err:
+        err_code = err.response["Error"]["Code"]
+        err_message = err.response["Error"]["Message"]
+        logger.error(f"Error occurred while fetching metadata of {key_path} from bucjet {bucket}: {err_code} {err_message}")
+        if_exist = False
+    finally:
+        s3_client.close()
+    return if_exist
+
+def parse_bucket_folder_path(bucket_folder_path:str) -> tuple:
+    """Extract bucket name and folder path from a bucket path str
+    
+    Example: "ccdi-staging/sub_folder1/sub_folder2"
+    Return values: ccdi-staging, "subfolder1/sub_folder2"
+    """
+    bucket_folder_path =  bucket_folder_path.strip("/")
+    if "/" in bucket_folder_path:
+        path_list =  bucket_folder_path.split("/", 1)
+        bucket, folder_path =  path_list
+    else:
+        bucket = bucket_folder_path
+        folder_path = ""
+    return bucket, folder_path
+
+def construct_staging_key(object_prod_bucket_key: str, prod_bucket_path: str, staging_bucket_path: str) -> str:
+    """Reconstruct the object key in staging bucket
+
+    Example:
+        object_prid_bucket_key: release_2/sub_dir1/sub_dir2/example.cram
+        prod_bucket_path: prod_bucket/release_2
+        staging_bucket_path: staging_bucket/staging_folder
+    Returns:
+        staging_bucket, staging_folder/sub_dir1/sub_dir2/example.cram
+    """
+    _, prod_prefix = parse_bucket_folder_path(bucket_folder_path=prod_bucket_path)
+    object_prod_bucket_key = object_prod_bucket_key.strip("/")
+    # remove the prefix part in prod bucket
+    object_without_prod_prefix = object_prod_bucket_key[len(prod_prefix):].strip("/")
+    # parse staging bucket path to staging bucket name, staging prefix
+    staging_bucket, staging_prefix = parse_bucket_folder_path(
+        bucket_folder_path=staging_bucket_path
+    )
+    # concatenate with staging bucket path
+    object_staging_bucket_key = os.path.join(staging_prefix, object_without_prod_prefix)
+    return staging_bucket, object_staging_bucket_key
+
+@task
+def get_md5sum(object_key: str, bucket: str) -> str:
+    """
+    Calculate md5sum of an object using url
+    This function was modified based on https://github.com/jmwarfe/s3-md5sum/blob/main/s3-md5sum.py
+
+    expect inputs: bucket_name, object_key
+    example: "ccdi-staging", "sub_dir1/sub_dir2/object_file.txt"
+    """
+    s3_client = set_s3_session_client()
+    # get obejct
+    obj = s3_client.get_object(Bucket=bucket, Key=object_key)
+    obj_body = obj["Body"]
+
+    # Initialize MD5 hash object
+    md5_hash = hashlib.md5()
+    # Read the object in chunks and update the MD5 hash
+    for chunk in iter(lambda: obj_body.read(1024 * 1024), b""):
+        md5_hash.update(chunk)
+    s3_client.close()
+    return md5_hash.hexdigest()
+
+@flow
+def objects_md5sum(list_keys: list, bucket_name: str):
+    """Get a list of md5sum using a list of keys and static bucket name
+
+    Example: 
+        list_keys = ["folder1/folder2/file1.txt","folder1/folder2/file2.txt","folder1/folder2/file3.txt"]
+        bucket_name = "ccdi-staging"
+    """
+    md5sum_futures = get_md5sum.map(list_keys, bucket_name)
+    md5sum_list = [i.result() for i in md5sum_futures]
+    print(md5sum_list)
+    return md5sum_list

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -314,7 +314,6 @@ def retrieve_objects_from_bucket_path(bucket_folder_path: str) -> list[dict]:
     return bucket_object_dict_list
 
 
-@flow(log_prints=True)
 def find_missing_objects(
     manifest_df: DataFrame, file_object_list: list[dict]
 ) -> DataFrame:
@@ -325,7 +324,7 @@ def find_missing_objects(
 
     # find nonexist files, df has four columns "Key","Size", "md5sum","Filename", "Missing_Object_Candidate_Keys"
     not_found_df = manifest_df.loc[manifest_df["Staging_If_Exist"]==False, ["Key", "Size", "md5sum"]]
-    not_found_df["Missing_Object_Candidate_Keys"] =""
+    print(not_found_df)
     not_found_df = not_found_df.assign(Filename = lambda x: (os.path.basename(x["Key"])))
     print(not_found_df)
 
@@ -345,7 +344,7 @@ def find_missing_objects(
             pass
         else:
             s3_client = set_s3_session_client()
-            h_md5sum = get_md5sum(
+            h_md5sum = get_md5sum.fn(
                 object_key=h['Key'], bucket_name=h['Bucket'], s3_client=s3_client
             )
             s3_client.close()

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -64,8 +64,9 @@ Do you have a manifest of s3 URI endpoints to be deleted :
         """
 **Please provide inputs as shown below**
 
-- **prod_bucket_path**: bucket path containig files you would like to keep
-- **staging_bucket_path**: bucket path contaings duplciated object under prod bucket path that you would like to delete
+- **prod_bucket_path**: bucket path containing files you would like to keep
+- **staging_bucket_path**: bucket path containing duplciated objects under prod bucket path that you would like to delete
+- **workflow_output_bucket**: the bucket where the workflow output will be uploaded to
 - **runner**: your runner id
 
 """

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -98,6 +98,9 @@ def list_to_chunks(mylist: list, chunk_len: int) -> list:
 
 
 def count_success_fail(deletion_status: list) -> tuple:
+    """Returns counts of successful deletion and counts of 
+    unsuccessful deletion
+    """
     count_success = deletion_status.count("Success")
     # count_fail = deletion_status.count("Fail")
     count_fail = len(deletion_status) - count_success
@@ -265,6 +268,8 @@ def delete_single_object_by_uri(object_uri: str, s3_client, logger) -> str:
     """Delete a single s3 uri"""
     bucket_name, object_key = parse_file_url_in_cds(url=object_uri)
     try:
+        # check if the object exist before deletion.
+        # if not found, return status "not found"
         s3_client.head_object(Bucket=bucket_name, Key=object_key)
         try:
             s3_client.delete_object(Bucket=bucket_name, Key=object_key)

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -313,7 +313,7 @@ def retrieve_objects_from_bucket_path(bucket_folder_path: str) -> list[dict]:
     s3.close()
     return bucket_object_dict_list
 
-@flow
+
 def find_missing_objects(
     manifest_df: DataFrame, file_object_list: list[dict]
 ) -> DataFrame:

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -313,7 +313,7 @@ def retrieve_objects_from_bucket_path(bucket_folder_path: str) -> list[dict]:
     s3.close()
     return bucket_object_dict_list
 
-
+@flow
 def find_missing_objects(
     manifest_df: DataFrame, file_object_list: list[dict]
 ) -> DataFrame:

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -1,4 +1,4 @@
-from prefect import flow, task
+from prefect import flow, task, get_run_logger
 from src.utils import set_s3_session_client
 from botocore.errorfactory import ClientError
 import os
@@ -90,7 +90,8 @@ def objects_md5sum(list_keys: list[str], bucket_name: str):
         list_keys = ["folder1/folder2/file1.txt","folder1/folder2/file2.txt","folder1/folder2/file3.txt"]
         bucket_name = "ccdi-staging"
     """
+    logger = get_run_logger()
     md5sum_futures = get_md5sum.map(list_keys, bucket_name)
     md5sum_list = [i.result() for i in md5sum_futures]
-    print(md5sum_list)
+    logger.info(f"md5sum list return is: {*md5sum_list,}")
     return md5sum_list

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -258,7 +258,7 @@ def objects_if_exist(key_path_list: list[str], bucket: str, logger) -> list:
     name="Delete Single S3 Object",
     retries=3,
     retry_delay_seconds=0.5,
-    tags=["concurrency-test"],
+    tags=["file-remover-tag"],
 )
 def delete_single_object_by_uri(object_uri: str, s3_client, logger) -> str:
     bucket_name, object_key = parse_file_url_in_cds(url=object_uri)

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -324,7 +324,7 @@ def find_missing_objects(
 
     # find nonexist files, df has four columns "Key","Size", "md5sum","Filename", "Missing_Object_Candidate_Keys"
     not_found_df = manifest_df.loc[manifest_df["Staging_If_Exist"]==False, ["Key", "Size", "md5sum"]]
-    not_found_df = not_found_df.assign(Filename = lambda x: (os.path.basename(x["Key"].values[0])))
+    not_found_df["Filename"] = [os.path.basename(i) for i in not_found_df["Key"].tolist()]
     print(not_found_df)
 
     # add file basename to file_object_list
@@ -557,6 +557,7 @@ def create_matching_object_manifest(prod_bucket_path: str, staging_bucket_path: 
     manifest_df["Staging_S3_URI"] = (
         "s3://" + manifest_df["Staging_Bucket"] + "/" + manifest_df["Staging_Key"]
     )
+    manifest_df.loc[manifest_df["Staging_If_Exist"] == False, "Staging_S3_URI"] = ""
 
     # write manifest into file
     logger.info(f"Writing output manifest {output_manifest_name}")

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -83,7 +83,7 @@ def get_md5sum(object_key: str, bucket: str) -> str:
     return md5_hash.hexdigest()
 
 @flow
-def objects_md5sum(list_keys: list, bucket_name: str):
+def objects_md5sum(list_keys: list[str], bucket_name: str):
     """Get a list of md5sum using a list of keys and static bucket name
 
     Example: 

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -124,6 +124,12 @@ def parse_bucket_folder_path(bucket_folder_path: str) -> tuple:
     Example: "ccdi-staging/sub_folder1/sub_folder2"
     Return values: ccdi-staging, "subfolder1/sub_folder2"
     """
+    # remove s3:// if observed
+    if bucket_folder_path.startswith("s3://"):
+        bucket_folder_path = bucket_folder_path[5:]
+    else:
+        pass
+
     bucket_folder_path = bucket_folder_path.strip("/")
     if "/" in bucket_folder_path:
         path_list = bucket_folder_path.split("/", 1)
@@ -352,7 +358,7 @@ def find_missing_objects(
 @flow
 def create_matching_object_manifest(prod_bucket_path: str, staging_bucket_path: str, runner: str) -> None:
     # get output name
-    output_manifest_name = runner + "_matching_objects_manifest_" + get_time + ".tsv"
+    output_manifest_name = runner + "_matching_objects_manifest_" + get_time() + ".tsv"
 
     # create logger
     logger = get_run_logger()

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -42,9 +42,9 @@ class InputDescriptionMD:
     have_manifest_md: str = (
         """
 **Welcome to the File Remover Flow!**
-Today's Date: {current_time}
+Today's Date: *{current_time}*
 
-Do you have a manifest of s3 URI endpoints to be deleted :
+Do you have a manifest containing **s3 URI endpoints** to be deleted :
 - **have_manifest**: y/n
 
 """
@@ -77,7 +77,7 @@ Do you have a manifest of s3 URI endpoints to be deleted :
 
 !!CAUTION!!
 
-Make sure you have reviewed the manifest {manifest_file} under bucket {bucket} folder {folder}
+Make sure you have reviewed the manifest *{manifest_file}* under bucket *{bucket}* folder *{folder}*
 
 - **proceed_to_delete**: y/n
 

--- a/src/read_buckets.py
+++ b/src/read_buckets.py
@@ -36,6 +36,10 @@ def count_df(mydict: Dict, newitem: str) -> Dict:
 
 
 def paginate_parameter(bucket_path: str) -> tuple:
+    if bucket_path.startswith("s3://"):
+        bucket_path = bucket_path[5:]
+    else:
+        pass
     bucket_path = bucket_path.strip("/")
     if "/" not in bucket_path:
         bucket_name = bucket_path

--- a/tests/test_file_remover.py
+++ b/tests/test_file_remover.py
@@ -1,0 +1,38 @@
+import sys
+import os
+import mock
+import pytest
+from unittest.mock import MagicMock
+from prefect.testing.utilities import prefect_test_harness
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(parent_dir)
+from src.file_remover import parse_bucket_folder_path, construct_staging_bucket_key
+
+
+def test_parse_bucket_folder_path():
+    """test for parse_bucket_folder_path"""
+    test_bucket_path_one = "test-bucket/sub_folder1/subfolder_2/subfolder_3/"
+    test_bucket_path_two = "test-bucket/sub_folder4"
+    one_bucket, one_folder_path = parse_bucket_folder_path(
+        bucket_folder_path=test_bucket_path_one
+    )
+    _, two_folder_path = parse_bucket_folder_path(
+        bucket_folder_path=test_bucket_path_two
+    )
+    assert one_bucket == "test-bucket"
+    assert one_folder_path == "sub_folder1/subfolder_2/subfolder_3"
+    assert two_folder_path == "sub_folder4"
+
+
+def test_construct_staging_bucket_key():
+    """test for construct_staging_bucket_key"""
+    object_prod_key = "release_2/sub_dir1/sub_dir2/example.cram"
+    prod_bucket_path = "prod_bucket/release_2"
+    staging_bucket_path = "staging_bucket/staging_folder"
+    staging_key = construct_staging_bucket_key.fn(
+        object_prod_bucket_key=object_prod_key,
+        prod_bucket_path=prod_bucket_path,
+        staging_bucket_path=staging_bucket_path,
+    )
+    assert staging_key == "staging_folder/sub_dir1/sub_dir2/example.cram"

--- a/tests/test_file_remover.py
+++ b/tests/test_file_remover.py
@@ -4,10 +4,17 @@ import mock
 import pytest
 from unittest.mock import MagicMock
 from prefect.testing.utilities import prefect_test_harness
+from botocore.exceptions import ClientError
 
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
-from src.file_remover import parse_bucket_folder_path, construct_staging_bucket_key
+from src.file_remover import (
+    parse_bucket_folder_path,
+    construct_staging_bucket_key,
+    count_success_fail,
+    if_object_exists,
+    delete_single_object_by_uri,
+)
 
 
 def test_parse_bucket_folder_path():
@@ -36,3 +43,77 @@ def test_construct_staging_bucket_key():
         staging_bucket_path=staging_bucket_path,
     )
     assert staging_key == "staging_folder/sub_dir1/sub_dir2/example.cram"
+
+
+def test_count_success_fail():
+    """test for count_success_fail"""
+    test_list = ["Success", "Success", "Fail", "Fail", "Success"]
+    count_success, count_fail = count_success_fail(deletion_status=test_list)
+    assert count_success == 3
+    assert count_fail == 2
+
+
+def test_if_object_exists_true():
+    s3_client = MagicMock()
+    logger = MagicMock()
+    s3_client.head_object.return_value = {"ContentLength": 123, "Expiration": "string"}
+    if_exist = if_object_exists.fn(
+        bucket="test-bucket",
+        key_path="test_folder/file.txt",
+        s3_client=s3_client,
+        logger=logger,
+    )
+    assert if_exist
+
+
+def test_if_object_exists_false():
+    s3_client = MagicMock()
+    logger = MagicMock()
+    s3_client.head_object.side_effect = ClientError(
+        operation_name="InvalidKey",
+        error_response={
+            "Error": {"Code": "TestErrorCode", "Message": "This is a custom message"}
+        },
+    )
+    if_exist = if_object_exists.fn(
+        bucket="test-bucket",
+        key_path="test_folder/file.txt",
+        s3_client=s3_client,
+        logger=logger,
+    )
+    assert not if_exist
+
+
+def test_delete_single_object_by_uri_success():
+    """test for delete_single_object_by_uri"""
+    s3_client = MagicMock()
+    logger = MagicMock()
+    s3_client.delete_object.return_value = {
+        "DeleteMarker": True,
+        "VersionId": "string",
+        "RequestCharged": "requester",
+    }
+    delete_status = delete_single_object_by_uri.fn(
+        object_uri="s3://test-bucket/folder/file.txt",
+        s3_client=s3_client,
+        logger=logger,
+    )
+    assert delete_status == "Success"
+
+
+def test_delete_single_object_by_uri_fail():
+    """test for delete_single_object_by_uri"""
+    s3_client = MagicMock()
+    logger = MagicMock()
+    s3_client.delete_object.side_effect = ClientError(
+        operation_name="InvalidKey",
+        error_response={
+            "Error": {"Code": "TestErrorCode", "Message": "This is a custom message"}
+        },
+    )
+    delete_status = delete_single_object_by_uri.fn(
+        object_uri="s3://test-bucket/folder/file.txt",
+        s3_client=s3_client,
+        logger=logger,
+    )
+    assert delete_status == "Fail"

--- a/tests/test_file_remover.py
+++ b/tests/test_file_remover.py
@@ -116,4 +116,7 @@ def test_delete_single_object_by_uri_fail():
         s3_client=s3_client,
         logger=logger,
     )
-    assert delete_status == "Fail"
+    assert (
+        delete_status
+        == "ClientError('An error occurred (TestErrorCode) when calling the InvalidKey operation: This is a custom message')"
+    )

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -1,28 +1,14 @@
 import sys
 import os
 from prefect import flow, pause_flow_run, get_run_logger
-from prefect.input import RunInput
+
 import prefect
 import boto3
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
 from src.utils import get_time
-
-
-class FlowPath(RunInput):
-    have_manifest: str
-
-class ManifestPath(RunInput):
-    bucket: str
-    manifest_tsv_path: str
-    delete_column_name: str
-    runner: str
-
-
-class UserInput(RunInput):
-    name: str
-    age: int
+from src.file_remover import InputDescriptionMD, FlowPathInput, ManifestPathInput, NoManifestPathInput
 
 
 @flow(log_prints=True)
@@ -30,47 +16,42 @@ def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
 
-    description_md = f"""
-**Welcome to the File Remover Flow!**
-Today's Date: {current_time}
-
-Please enter your preferred path below:
-- **have_manifest**: y/n
-
-"""
-
-    description_manifest_md = f"""
-**Please provide inputs as shown below**
-
-- **bucket**: bucket name of where manifest lives
-- **manifest_tsv_path**: path of manifest(tsv) in the bucket
-- **delete_column_name**: column name of s3 uri to be deleted
-- **runner**: your runner id
-
-"""
-
     user_input = pause_flow_run(
-        wait_for_input=FlowPath.with_initial_data(
-            description=description_md, have_manifest="y"
+        wait_for_input=FlowPathInput.with_initial_data(
+            description=InputDescriptionMD.manifest_inputs_md.format(current_time=current_time), have_manifest="y"
         )
     )
 
     if user_input.have_manifest == "y":
         logger.info("You have a manifest for File Remover")
         manifest_path_inputs = pause_flow_run(
-            wait_for_input=ManifestPath.with_initial_data(
-                description=description_manifest_md, bucket="ccdi-validation"
+            wait_for_input=ManifestPathInput.with_initial_data(
+                description=InputDescriptionMD.manifest_inputs_md, bucket="ccdi-validation"
             )
         )
 
-        logger.info(f"bucket: {manifest_path_inputs.bucket}")
-        logger.info(f"manifest_tsv_path: {manifest_path_inputs.manifest_tsv_path}")
-        logger.info(f"delete_column_name: {manifest_path_inputs.delete_column_name}")
-        logger.info(f"runner id: {manifest_path_inputs.runner}")
+        logger.info(
+            f"bucket: {manifest_path_inputs.bucket}"
+            + "\n"
+            + f"manifest_tsv_path: {manifest_path_inputs.manifest_tsv_path}"
+            + "\n"
+            + f"delete_column_name: {manifest_path_inputs.delete_column_name}"
+            + "\n"
+            + f"runner id: {manifest_path_inputs.runner}"
+        )
 
     else:
-        logger.info(f"You don't have a manifest for File Remover!")
-
+        logger.info("You don't have a manifest. To proceed, please provide a prod bucket path and a staging bucket path")
+        no_manifest_path_inputs = pause_flow_run(
+            wait_for_input= NoManifestPathInput.with_initial_data(
+                description=InputDescriptionMD.no_manifest_inputs_md
+            )
+        )
+        logger.info(
+            f"prod_bucket_path: {no_manifest_path_inputs.prod_bucket_path}"
+              + "\n" + f"staging_bucket_path: {no_manifest_path_inputs.staging_bucket_path}"
+              + "\n" + f"runner: {no_manifest_path_inputs.runner}"
+        )
 
 
 if __name__=="__main__":

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -29,19 +29,6 @@ class UserInput(RunInput):
 def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
-    print(f"current time is {current_time}")
-    print(prefect.__version__)
-    
-    f=open("requirements.txt")
-    file_content = f.read()
-    print(file_content)
-    f.close()
-
-    print(boto3.__version__)
-
-    user = pause_flow_run(wait_for_input=str)
-
-    logger.info(f"Hello, {user}!")
 
     description_md = f"""
 **Welcome to the File Remover Flow!**
@@ -62,7 +49,6 @@ Please enter your preferred path below:
 
 """
 
-"""
     user_input = pause_flow_run(
         wait_for_input=FlowPath.with_initial_data(
             description=description_md, have_manifest="y"
@@ -84,7 +70,7 @@ Please enter your preferred path below:
 
     else:
         logger.info(f"You don't have a manifest for File Remover!")
-"""
+
 
 
 if __name__=="__main__":

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -3,6 +3,7 @@ import os
 from prefect import flow, pause_flow_run, get_run_logger
 from prefect.input import RunInput
 import prefect
+import pip
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
@@ -30,6 +31,11 @@ def run_file_remover():
     current_time = get_time()
     print(f"current time is {current_time}")
     print(prefect.__version__)
+
+    installed_packages = sorted(
+        ["%s==%s" % (i.key, i.version) for i in pip.get_installed_distributions()]
+    )
+    print(installed_packages)
 
     user = pause_flow_run(wait_for_input=str)
 
@@ -78,7 +84,6 @@ Please enter your preferred path below:
         logger.info(f"You don't have a manifest for File Remover!")
 """
 
-    
 
 if __name__=="__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -18,7 +18,7 @@ from src.file_remover import (
 
 
 @flow(name="File Remover Pipeline", log_prints=True)
-def run_file_remover(do_you_have_tsv_manifest:str ="y/n"):
+def run_file_remover(do_you_have_tsv_manifest:str):
     logger = get_run_logger()
     #current_time = get_time()
 
@@ -173,7 +173,7 @@ def run_file_remover(do_you_have_tsv_manifest:str ="y/n"):
             )
             logger.info("File Remover workflow finished!")
     else:
-        raise ValueError("You provided invalid answer. Please use y or n")
+        raise ValueError(f"You provided invalid answer {do_you_have_tsv_manifest}. Please use y or n")
 
 if __name__ == "__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -137,7 +137,12 @@ def run_file_remover():
         )
         deletion_input = pause_flow_run(
             wait_for_input=ObjectDeletionInput.with_initial_data(
-                description=InputDescriptionMD.object_deletion_md, proceed_to_delete="n"
+                description=InputDescriptionMD.object_deletion_md.format(
+                    manifest_file=manifest_file,
+                    bucket=no_manifest_path_inputs.workflow_output_bucket,
+                    folder=output_folder,
+                ),
+                proceed_to_delete="n",
             )
         )
         if deletion_input.proceed_to_delete == "y":

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -4,11 +4,20 @@ from prefect import flow, pause_flow_run, get_run_logger
 
 import prefect
 import boto3
+
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
-from src.utils import get_time
-from src.file_remover import InputDescriptionMD, FlowPathInput, ManifestPathInput, NoManifestPathInput
+from src.utils import get_time, file_dl, file_ul
+from src.file_remover import (
+    InputDescriptionMD,
+    FlowPathInput,
+    ManifestPathInput,
+    NoManifestPathInput,
+    ObjectDeletionInput,
+    objects_deletion,
+    create_matching_object_manifest,
+)
 
 
 @flow(log_prints=True)
@@ -29,11 +38,13 @@ def run_file_remover():
         logger.info("You have a manifest for File Remover")
         manifest_path_inputs = pause_flow_run(
             wait_for_input=ManifestPathInput.with_initial_data(
-                description=InputDescriptionMD.manifest_inputs_md, bucket="ccdi-validation"
+                description=InputDescriptionMD.manifest_inputs_md,
+                bucket="ccdi-validation",
             )
         )
 
         logger.info(
+            "Inputs received:" + "\n"
             f"bucket: {manifest_path_inputs.bucket}"
             + "\n"
             + f"manifest_tsv_path: {manifest_path_inputs.manifest_tsv_path}"
@@ -43,19 +54,114 @@ def run_file_remover():
             + f"runner id: {manifest_path_inputs.runner}"
         )
 
+        # download the manifest from bucket
+        file_dl(
+            bucket=manifest_path_inputs.bucket,
+            filename=manifest_path_inputs.manifest_tsv_path,
+        )
+        logger.info(
+            f"Downloaded manifest {manifest_path_inputs.manifest_tsv_path} from bucket {manifest_path_inputs.bucket}"
+        )
+        manifest_file = os.path.basename(manifest_path_inputs.manifest_tsv_path)
+
+        # start deleting objects in manifest
+        logger.info("Start objects deletion process")
+        deletion_summary = objects_deletion(
+            manifest_file_path=manifest_file,
+            delete_column_name=manifest_path_inputs.delete_column_name,
+            runner=manifest_path_inputs.runner,
+        )
+        logger.info(
+            f"Objects deletion finished and a summary table has been generated {deletion_summary}"
+        )
+
+        # upload the deletion summary to bucket
+        output_folder = (
+            manifest_path_inputs.runner + "/" + "_file_remover_summary_" + get_time()
+        )
+        file_ul(
+            bucket=manifest_path_inputs.bucket,
+            output_folder=output_folder,
+            sub_folder="",
+            newfile=deletion_summary,
+        )
+        logger.info(
+            f"Uploaded summary table to bucket {manifest_path_inputs.bucket} under folder {output_folder}"
+        )
+        logger.info("File Remover workflow finished!")
+
     else:
-        logger.info("You don't have a manifest. To proceed, please provide a prod bucket path and a staging bucket path")
+        logger.info(
+            "You don't have a manifest. To proceed, please provide a prod bucket path and a staging bucket path"
+        )
         no_manifest_path_inputs = pause_flow_run(
-            wait_for_input= NoManifestPathInput.with_initial_data(
+            wait_for_input=NoManifestPathInput.with_initial_data(
                 description=InputDescriptionMD.no_manifest_inputs_md
             )
         )
         logger.info(
+            "Inputs received:" + "\n"
             f"prod_bucket_path: {no_manifest_path_inputs.prod_bucket_path}"
-              + "\n" + f"staging_bucket_path: {no_manifest_path_inputs.staging_bucket_path}"
-              + "\n" + f"runner: {no_manifest_path_inputs.runner}"
+            + "\n"
+            + f"staging_bucket_path: {no_manifest_path_inputs.staging_bucket_path}"
+            + "\n"
+            + f"workflow_output_bucket: {no_manifest_path_inputs.workflow_output_bucket}"
+            + "\n"
+            + f"runner: {no_manifest_path_inputs.runner}"
         )
 
+        logger.info(
+            f"Start generating a manifest using provided prod_bucket_path {no_manifest_path_inputs.prod_bucket_path} and staging_bucket_path {no_manifest_path_inputs.staging_bucket_path}"
+        )
+        manifest_file = create_matching_object_manifest(
+            prod_bucket_path=no_manifest_path_inputs.prod_bucket_path,
+            staging_bucket_path=no_manifest_path_inputs.staging_bucket_path,
+            runner=no_manifest_path_inputs.runner,
+        )
+        logger.info("Generated a manifest for objects deletion")
 
-if __name__=="__main__":
+        # upload the manifest to bucket
+        # upload the deletion summary to bucket
+        output_folder = (
+            no_manifest_path_inputs.runner + "/" + "_file_remover_summary_" + get_time()
+        )
+        file_ul(
+            bucket=no_manifest_path_inputs.workflow_output_bucket,
+            output_folder=output_folder,
+            sub_folder="",
+            newfile=manifest_file,
+        )
+        logger.info(
+            f"Uploaded manifest {manifest_file} to bucket {no_manifest_path_inputs.workflow_output_bucket} under folder {output_folder}. Please check the manifest before deletion."
+        )
+        deletion_input = pause_flow_run(
+            wait_for_input=ObjectDeletionInput.with_initial_data(
+                description=InputDescriptionMD.object_deletion_md, proceed_to_delete="n"
+            )
+        )
+        if deletion_input.proceed_to_delete == "y":
+            logger.info("Start objects deletion process")
+            deletion_summary = objects_deletion(
+                manifest_file_path=manifest_file,
+                delete_column_name="Staging_S3_URI",
+                runner=no_manifest_path_inputs.runner,
+            )
+            logger.info(f"Objects deletion finished and a summary table has been generated {deletion_summary}")
+
+            # upload deletion_summary to bucket
+            file_ul(
+                bucket=no_manifest_path_inputs.workflow_output_bucket,
+                output_folder=output_folder,
+                sub_folder="",
+                newfile=deletion_summary,
+            )
+            logger.info(f"Uploaded deletion summaru table {deletion_summary} to bucket {no_manifest_path_inputs.workflow_output_bucket} under folder {output_folder}")
+            logger.info("File Remover workflow finished!")
+        else:
+            logger.info(
+                f"You chose not to proceed with deletion this time.\nYou can restart the flow whenever you're ready.\nManifest location: {no_manifest_path_inputs.workflow_output_bucket}/{output_folder}/{manifest_file}"
+            )
+            logger.info("File Remover workflow finished!")
+
+if __name__ == "__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -20,7 +20,7 @@ from src.file_remover import (
 )
 
 
-@flow(log_prints=True)
+@flow(name="File Remover Pipeline", log_prints=True)
 def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
@@ -66,18 +66,19 @@ def run_file_remover():
 
         # start deleting objects in manifest
         logger.info("Start objects deletion process")
-        deletion_summary = objects_deletion(
+        deletion_summary, deletion_counts_df = objects_deletion(
             manifest_file_path=manifest_file,
             delete_column_name=manifest_path_inputs.delete_column_name,
             runner=manifest_path_inputs.runner,
         )
+        logger.info(deletion_counts_df.to_markdown(index=False, tablefmt="simple_grid"))
         logger.info(
             f"Objects deletion finished and a summary table has been generated {deletion_summary}"
         )
 
         # upload the deletion summary to bucket
         output_folder = (
-            manifest_path_inputs.runner + "/" + "_file_remover_summary_" + get_time()
+            manifest_path_inputs.runner + "/" + "file_remover_summary_" + get_time()
         )
         file_ul(
             bucket=manifest_path_inputs.bucket,
@@ -123,7 +124,7 @@ def run_file_remover():
         # upload the manifest to bucket
         # upload the deletion summary to bucket
         output_folder = (
-            no_manifest_path_inputs.runner + "/" + "_file_remover_summary_" + get_time()
+            no_manifest_path_inputs.runner + "/" + "file_remover_summary_" + get_time()
         )
         file_ul(
             bucket=no_manifest_path_inputs.workflow_output_bucket,
@@ -141,10 +142,13 @@ def run_file_remover():
         )
         if deletion_input.proceed_to_delete == "y":
             logger.info("Start objects deletion process")
-            deletion_summary = objects_deletion(
+            deletion_summary, deletion_counts_df = objects_deletion(
                 manifest_file_path=manifest_file,
                 delete_column_name="Staging_S3_URI",
                 runner=no_manifest_path_inputs.runner,
+            )
+            logger.info(
+                deletion_counts_df.to_markdown(index=False, tablefmt="simple_grid")
             )
             logger.info(f"Objects deletion finished and a summary table has been generated {deletion_summary}")
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -2,6 +2,7 @@ import sys
 import os
 from prefect import flow, pause_flow_run, get_run_logger
 from prefect.input import RunInput
+import prefect
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
@@ -23,10 +24,12 @@ class UserInput(RunInput):
     age: int
 
 
-@flow
+@flow(log_prints=True)
 def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
+    print(f"current time is {current_time}")
+    print(prefect.__version__)
 
     user = pause_flow_run(wait_for_input=str)
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -24,7 +24,7 @@ class UserInput(RunInput):
 
 
 @flow
-async def run_file_remover():
+def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
 
@@ -47,8 +47,8 @@ Please enter your preferred path below:
 
 """
 
-    """
-    user_input = await pause_flow_run(
+
+    user_input = pause_flow_run(
         wait_for_input=FlowPath.with_initial_data(
             description=description_md, have_manifest="y"
         )
@@ -56,7 +56,7 @@ Please enter your preferred path below:
 
     if user_input.have_manifest == "y":
         logger.info("You have a manifest for File Remover")
-        manifest_path_inputs = await pause_flow_run(
+        manifest_path_inputs = pause_flow_run(
             wait_for_input=ManifestPath.with_initial_data(
                 description=description_manifest_md, bucket="ccdi-validation"
             )
@@ -69,12 +69,7 @@ Please enter your preferred path below:
 
     else:
         logger.info(f"You don't have a manifest for File Remover!")
-    """
-    user_input = await pause_flow_run(
-        wait_for_input=UserInput.with_initial_data(name="anonymous")
-    )
 
-    if user_input.name == "anonymous":
-        logger.info("Hello, stranger!")
-    else:
-        logger.info(f"Hello, {user_input.name}!")
+
+if __name__=="__main__":
+    run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -18,6 +18,11 @@ class ManifestPath(RunInput):
     runner: str
 
 
+class UserInput(RunInput):
+    name: str
+    age: int
+
+
 @flow
 async def run_file_remover():
     logger = get_run_logger()
@@ -42,6 +47,7 @@ Please enter your preferred path below:
 
 """
 
+    """
     user_input = await pause_flow_run(
         wait_for_input=FlowPath.with_initial_data(
             description=description_md, have_manifest="y"
@@ -63,3 +69,12 @@ Please enter your preferred path below:
 
     else:
         logger.info(f"You don't have a manifest for File Remover!")
+    """
+    user_input = await pause_flow_run(
+        wait_for_input=UserInput.with_initial_data(name="anonymous")
+    )
+
+    if user_input.name == "anonymous":
+        logger.info("Hello, stranger!")
+    else:
+        logger.info(f"Hello, {user_input.name}!")

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -18,7 +18,10 @@ def run_file_remover():
 
     user_input = pause_flow_run(
         wait_for_input=FlowPathInput.with_initial_data(
-            description=InputDescriptionMD.manifest_inputs_md.format(current_time=current_time), have_manifest="y"
+            description=InputDescriptionMD.have_manifest_md.format(
+                current_time=current_time
+            ),
+            have_manifest="y",
         )
     )
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -28,6 +28,10 @@ def run_file_remover():
     logger = get_run_logger()
     current_time = get_time()
 
+    user = pause_flow_run(wait_for_input=str)
+
+    logger.info(f"Hello, {user}!")
+
     description_md = f"""
 **Welcome to the File Remover Flow!**
 Today's Date: {current_time}
@@ -43,11 +47,11 @@ Please enter your preferred path below:
 - **bucket**: bucket name of where manifest lives
 - **manifest_tsv_path**: path of manifest(tsv) in the bucket
 - **delete_column_name**: column name of s3 uri to be deleted
-- **runner**": your runner id
+- **runner**: your runner id
 
 """
 
-
+"""
     user_input = pause_flow_run(
         wait_for_input=FlowPath.with_initial_data(
             description=description_md, have_manifest="y"
@@ -69,7 +73,9 @@ Please enter your preferred path below:
 
     else:
         logger.info(f"You don't have a manifest for File Remover!")
+"""
 
+    
 
 if __name__=="__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -71,7 +71,7 @@ def run_file_remover():
             delete_column_name=manifest_path_inputs.delete_column_name,
             runner=manifest_path_inputs.runner,
         )
-        logger.info(deletion_counts_df.to_markdown(index=False, tablefmt="simple_grid"))
+        logger.info(deletion_counts_df.to_markdown(index=False, tablefmt="rst"))
         logger.info(
             f"Objects deletion finished and a summary table has been generated {deletion_summary}"
         )
@@ -148,7 +148,7 @@ def run_file_remover():
                 runner=no_manifest_path_inputs.runner,
             )
             logger.info(
-                deletion_counts_df.to_markdown(index=False, tablefmt="simple_grid")
+                deletion_counts_df.to_markdown(index=False, tablefmt="rst")
             )
             logger.info(f"Objects deletion finished and a summary table has been generated {deletion_summary}")
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -18,10 +18,11 @@ from src.file_remover import (
 
 
 @flow(name="File Remover Pipeline", log_prints=True)
-def run_file_remover():
+def run_file_remover(do_you_have_tsv_manifest:str ="y/n"):
     logger = get_run_logger()
-    current_time = get_time()
+    #current_time = get_time()
 
+    """
     user_input = pause_flow_run(
         wait_for_input=FlowPathInput.with_initial_data(
             description=InputDescriptionMD.have_manifest_md.format(
@@ -30,8 +31,11 @@ def run_file_remover():
             have_manifest="y",
         )
     )
+    """
+    
 
-    if user_input.have_manifest == "y":
+    #if user_input.have_manifest == "y":
+    if do_you_have_tsv_manifest == "y":
         logger.info("You have a manifest for File Remover")
         manifest_path_inputs = pause_flow_run(
             wait_for_input=ManifestPathInput.with_initial_data(
@@ -87,7 +91,8 @@ def run_file_remover():
         )
         logger.info("File Remover workflow finished!")
 
-    else:
+    #else:
+    elif do_you_have_tsv_manifest == "n":
         logger.info(
             "You don't have a manifest. To proceed, please provide a prod bucket path and a staging bucket path"
         )
@@ -167,7 +172,8 @@ def run_file_remover():
                 f"You chose not to proceed with deletion this time.\nYou can restart the flow whenever you're ready.\nManifest location: {no_manifest_path_inputs.workflow_output_bucket}/{output_folder}/{manifest_file}"
             )
             logger.info("File Remover workflow finished!")
-
+    else:
+        raise ValueError("You provided invalid answer. Please use y or n")
 
 if __name__ == "__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -3,7 +3,7 @@ import os
 from prefect import flow, pause_flow_run, get_run_logger
 from prefect.input import RunInput
 import prefect
-import pip
+import boto3
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 
@@ -31,11 +31,13 @@ def run_file_remover():
     current_time = get_time()
     print(f"current time is {current_time}")
     print(prefect.__version__)
+    
+    f=open("requirements.txt")
+    file_content = f.read()
+    print(file_content)
+    f.close()
 
-    installed_packages = sorted(
-        ["%s==%s" % (i.key, i.version) for i in pip.get_installed_distributions()]
-    )
-    print(installed_packages)
+    print(boto3.__version__)
 
     user = pause_flow_run(wait_for_input=str)
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -2,9 +2,6 @@ import sys
 import os
 from prefect import flow, pause_flow_run, get_run_logger
 
-import prefect
-import boto3
-
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -66,7 +66,6 @@ def run_file_remover():
         deletion_summary, deletion_counts_df = objects_deletion(
             manifest_file_path=manifest_file,
             delete_column_name=manifest_path_inputs.delete_column_name,
-            runner=manifest_path_inputs.runner,
         )
         logger.info(deletion_counts_df.to_markdown(index=False, tablefmt="rst"))
         logger.info(
@@ -114,7 +113,6 @@ def run_file_remover():
         manifest_file = create_matching_object_manifest(
             prod_bucket_path=no_manifest_path_inputs.prod_bucket_path,
             staging_bucket_path=no_manifest_path_inputs.staging_bucket_path,
-            runner=no_manifest_path_inputs.runner,
         )
         logger.info("Generated a manifest for objects deletion")
 
@@ -147,12 +145,11 @@ def run_file_remover():
             deletion_summary, deletion_counts_df = objects_deletion(
                 manifest_file_path=manifest_file,
                 delete_column_name="Staging_S3_URI",
-                runner=no_manifest_path_inputs.runner,
             )
+            logger.info(deletion_counts_df.to_markdown(index=False, tablefmt="rst"))
             logger.info(
-                deletion_counts_df.to_markdown(index=False, tablefmt="rst")
+                f"Objects deletion finished and a summary table has been generated {deletion_summary}"
             )
-            logger.info(f"Objects deletion finished and a summary table has been generated {deletion_summary}")
 
             # upload deletion_summary to bucket
             file_ul(
@@ -161,13 +158,16 @@ def run_file_remover():
                 sub_folder="",
                 newfile=deletion_summary,
             )
-            logger.info(f"Uploaded deletion summaru table {deletion_summary} to bucket {no_manifest_path_inputs.workflow_output_bucket} under folder {output_folder}")
+            logger.info(
+                f"Uploaded deletion summaru table {deletion_summary} to bucket {no_manifest_path_inputs.workflow_output_bucket} under folder {output_folder}"
+            )
             logger.info("File Remover workflow finished!")
         else:
             logger.info(
                 f"You chose not to proceed with deletion this time.\nYou can restart the flow whenever you're ready.\nManifest location: {no_manifest_path_inputs.workflow_output_bucket}/{output_folder}/{manifest_file}"
             )
             logger.info("File Remover workflow finished!")
+
 
 if __name__ == "__main__":
     run_file_remover()

--- a/workflows/File_Remover.py
+++ b/workflows/File_Remover.py
@@ -1,0 +1,65 @@
+import sys
+import os
+from prefect import flow, pause_flow_run, get_run_logger
+from prefect.input import RunInput
+parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(parent_dir)
+
+from src.utils import get_time
+
+
+class FlowPath(RunInput):
+    have_manifest: str
+
+class ManifestPath(RunInput):
+    bucket: str
+    manifest_tsv_path: str
+    delete_column_name: str
+    runner: str
+
+
+@flow
+async def run_file_remover():
+    logger = get_run_logger()
+    current_time = get_time()
+
+    description_md = f"""
+**Welcome to the File Remover Flow!**
+Today's Date: {current_time}
+
+Please enter your preferred path below:
+- **have_manifest**: y/n
+
+"""
+
+    description_manifest_md = f"""
+**Please provide inputs as shown below**
+
+- **bucket**: bucket name of where manifest lives
+- **manifest_tsv_path**: path of manifest(tsv) in the bucket
+- **delete_column_name**: column name of s3 uri to be deleted
+- **runner**": your runner id
+
+"""
+
+    user_input = await pause_flow_run(
+        wait_for_input=FlowPath.with_initial_data(
+            description=description_md, have_manifest="y"
+        )
+    )
+
+    if user_input.have_manifest == "y":
+        logger.info("You have a manifest for File Remover")
+        manifest_path_inputs = await pause_flow_run(
+            wait_for_input=ManifestPath.with_initial_data(
+                description=description_manifest_md, bucket="ccdi-validation"
+            )
+        )
+
+        logger.info(f"bucket: {manifest_path_inputs.bucket}")
+        logger.info(f"manifest_tsv_path: {manifest_path_inputs.manifest_tsv_path}")
+        logger.info(f"delete_column_name: {manifest_path_inputs.delete_column_name}")
+        logger.info(f"runner id: {manifest_path_inputs.runner}")
+
+    else:
+        logger.info(f"You don't have a manifest for File Remover!")


### PR DESCRIPTION
## Added Features

- Added interactive `file_remover` workflow. User can start the workflow with a tsv manifest which contains a column of s3 uri to be deleted, or without manifest. When running without manifest, user need to provide a production bucket path and a staging bucket path, and the workflow will try to find object match between two locations. 

- Added unittests for `file_remover`