### PR TITLE
CCDIDC-1094 bucket reader bug

### DIFF
--- a/src/read_buckets.py
+++ b/src/read_buckets.py
@@ -40,7 +40,12 @@ def paginate_parameter(bucket_path: str) -> tuple:
         bucket_path = bucket_path[5:]
     else:
         pass
-    bucket_path = bucket_path.strip("/")
+    # make sure path ends with "/" even only bucket name
+    if not bucket_path.endswith("/"):
+        bucket_path = bucket_path + "/"
+    else:
+        pass
+    #bucket_path = bucket_path.strip("/")
     if "/" not in bucket_path:
         bucket_name = bucket_path
         prefix = ""

--- a/tests/test_read_buckets.py
+++ b/tests/test_read_buckets.py
@@ -159,8 +159,8 @@ def test_read_bucket_content(mock_s3_client, paginate_return_iter):
 @pytest.mark.parametrize(
         "bucket_path,expected",
         [("my-bucket",{"Bucket":"my-bucket", "Prefix":""}),
-         ("my-bucket/test_subdir/",{"Bucket":"my-bucket","Prefix":"test_subdir"}),
-         ("my-bucket/subdir/more_subdir/",{"Bucket":"my-bucket", "Prefix":"subdir/more_subdir"})
+         ("my-bucket/test_subdir/",{"Bucket":"my-bucket","Prefix":"test_subdir/"}),
+         ("my-bucket/subdir/more_subdir/",{"Bucket":"my-bucket", "Prefix":"subdir/more_subdir/"})
         ]
 )
 def test_paginate_parameter(bucket_path, expected):


### PR DESCRIPTION
## Added patch

- Enforce the `Prefix` of `paginate_parameter` to end with `/`