### PR TITLE
1.9.0 fixes

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ pull:
   - prefect.projects.steps.git_clone_project:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-      branch: CCDIDC-1214---1.9.0_fixes
+      branch: main
   - prefect.projects.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"
@@ -422,28 +422,5 @@ deployments:
     # infra-specific fields
     work_pool:
       name: ccdi-curation-2gb
-      work_queue_name: null
-      job_variables: {}
-
-  - name: TEST-1.9.0-ccdi-data-curation-8gb
-    version: null
-    tags: ["TEST"]
-    description: null
-    entrypoint: workflows/s3-Prefect-Pipeline.py:runner
-    schedule: null
-
-    # flow-specific parameters
-    parameters:
-      bucket: "ccdi-validation"
-      file_path: "inputs/CCDI_Submission_Template_v1.7.2_10ExampleR20231228.xlsx"
-      runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
-
-    # infra-specific fields
-    work_pool:
-      name: ccdi-curation-8gb
       work_queue_name: null
       job_variables: {}

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ pull:
   - prefect.projects.steps.git_clone_project:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-      branch: main
+      branch: CCDIDC-1214---1.9.0_fixes
   - prefect.projects.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"
@@ -422,5 +422,28 @@ deployments:
     # infra-specific fields
     work_pool:
       name: ccdi-curation-2gb
+      work_queue_name: null
+      job_variables: {}
+
+  - name: TEST-1.9.0-ccdi-data-curation-8gb
+    version: null
+    tags: ["TEST"]
+    description: null
+    entrypoint: workflows/s3-Prefect-Pipeline.py:runner
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+      file_path: "inputs/CCDI_Submission_Template_v1.7.2_10ExampleR20231228.xlsx"
+      runner: "your_uniq_id"
+      #optional parmaeters below, uncomment if needed
+      #output_folder: "output_folder_name"
+      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
+      #sra_template_path: "inputs/phsXXXXXX.xlsx"
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-curation-8gb
       work_queue_name: null
       job_variables: {}

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -27,7 +27,7 @@ from typing import TypeVar
 DataFrame = TypeVar("DataFrame")
 
 
-def parse_file_url_in_cds(url: str) -> tuple:
+def parse_file_url(url: str) -> tuple:
     """Parse an s3 uri into bucket name and key"""
     # add s3:// if missing
     if not url.startswith("s3://"):
@@ -55,9 +55,9 @@ def copy_object_parameter(url_in_cds: str, dest_bucket_path: str) -> dict:
         'Bucket': 'my-source-bucket',
         'CopySource': 'ccdi-validation/QL/file2.txt',
         'Key': 'new_release/QL/file2.txt'
-     }
+    }
     """
-    origin_bucket, object_key = parse_file_url_in_cds(url=url_in_cds)
+    origin_bucket, object_key = parse_file_url(url=url_in_cds)
     if "/" not in dest_bucket_path:
         dest_bucket_path = dest_bucket_path + "/"
     else:
@@ -78,7 +78,7 @@ def dest_object_url(url_in_cds: str, dest_bucket_path: str) -> str:
     Expected Return
     "s3://new-bucket/release5/QL/inputs/file1.txt"
     """
-    orgin_bucket, object_key = parse_file_url_in_cds(url=url_in_cds)
+    orgin_bucket, object_key = parse_file_url(url=url_in_cds)
     dest_url = os.path.join("s3://", dest_bucket_path, object_key)
     return dest_url
 
@@ -377,7 +377,7 @@ def list_to_chunks(mylist: list, chunk_len: int) -> list:
     flow_run_name="move-manifest-files-" + f"{get_time()}",
 )
 def move_manifest_files(manifest_path: str, dest_bucket_path: str):
-    """Checks file node sheets and replaces the "file_url_in_cds"
+    """Checks file node sheets and replaces the "file_url"
     with a new url in prod bucket
     Returns a new manifest with new
     """
@@ -434,7 +434,7 @@ def move_manifest_files(manifest_path: str, dest_bucket_path: str):
             runner_logger.info(
                 f"Number of file objects in node {node}: {node_df_rmna.shape[0]}"
             )
-            node_file_urls = node_df["file_url_in_cds"].tolist()
+            node_file_urls = node_df["file_url"].tolist()
             new_node_file_urls = [
                 dest_object_url(url_in_cds=i, dest_bucket_path=dest_bucket_path)
                 for i in node_file_urls
@@ -455,7 +455,7 @@ def move_manifest_files(manifest_path: str, dest_bucket_path: str):
             # concatenate node_transfer_df to transfer_df
             transfer_df = pd.concat([transfer_df, node_transfer_df], ignore_index=True)
             # replace the old url with new url in the output
-            node_df["file_url_in_cds"] = new_node_file_urls
+            node_df["file_url"] = new_node_file_urls
             with pd.ExcelWriter(
                 output_name, mode="a", engine="openpyxl", if_sheet_exists="overlay"
             ) as writer:

--- a/src/file_remover.py
+++ b/src/file_remover.py
@@ -1,7 +1,7 @@
 from prefect import flow, task, get_run_logger
 from src.utils import set_s3_session_client
 from src.read_buckets import paginate_parameter
-from src.file_mover import parse_file_url_in_cds
+from src.file_mover import parse_file_url
 from botocore.exceptions import ClientError
 from dataclasses import dataclass
 from prefect.input import RunInput
@@ -276,7 +276,7 @@ def objects_if_exist(key_path_list: list[str], bucket: str, logger) -> list:
 )
 def delete_single_object_by_uri(object_uri: str, s3_client, logger) -> str:
     """Delete a single s3 uri"""
-    bucket_name, object_key = parse_file_url_in_cds(url=object_uri)
+    bucket_name, object_key = parse_file_url(url=object_uri)
     try:
         # check if the object exist before deletion.
         # if not found, return status "not found"

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -436,6 +436,11 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
                         )
 
                 meta_dfs[node] = df
+        
+        print(
+            "\nFile access checks and value creation complete.\n",
+            file=outf,
+        )
 
         ##############
         #

--- a/src/s3_catcherry.py
+++ b/src/s3_catcherry.py
@@ -418,7 +418,7 @@ def CatchERRy(file_path: str, template_path: str):  # removed profile
                 authz_value = f"['/programs/{dbgap_accession}']"
 
                 # for each row, determine if the ACL is properly formed and fix otherwise
-                for index, row in df.itterows():
+                for index, row in df.iterrows():
                     file_access_value = df.at[index, "file_access"]
 
                     if file_access_value == "Open":

--- a/src/s3_ccdi_to_cds.py
+++ b/src/s3_ccdi_to_cds.py
@@ -289,8 +289,8 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
                 node_df[col_base] = node_df[col_x].combine_first(node_df[col_y])
                 node_df.drop(columns=[col_x, col_y], inplace=True)
         # clean up the data frame, drop empty columns, rows that don't have files, reset index and remove duplicates.
-        if "file_url_in_cds" in node_df.columns:
-            node_df = node_df.dropna(subset=["file_url_in_cds"])
+        if "file_url" in node_df.columns:
+            node_df = node_df.dropna(subset=["file_url"])
         node_df = node_df.dropna(axis=1, how="all").reset_index(drop=True)
         # node_df = node_df.reset_index(drop=True)
         node_df = node_df.drop_duplicates()
@@ -961,7 +961,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     simple_add("file_name", "file_name")
     simple_add("file_size", "file_size")
     simple_add("file_type", "file_type")
-    simple_add("file_url_in_cds", "file_url_in_cds")
+    simple_add("file_url_in_cds", "file_url")
     simple_add("instrument_model", "instrument_model")
     simple_add("library_id", "library_id")
     simple_add("library_layout", "library_layout")
@@ -1010,7 +1010,7 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
     # simple_add('age_at_diagnosis','age_at_diagnosis')
 
     # Remove any rows where there is not a file associated with the entry
-    cds_df = cds_df.dropna(subset=["file_url_in_cds"])
+    cds_df = cds_df.dropna(subset=["file_url"])
 
     # Minor fix, if sample_id has no value, then sample_type/sample_anatomic_site should not have a value.
     cds_df.loc[cds_df["sample_id"].isnull(), "sample_type"] = None
@@ -1029,10 +1029,10 @@ def CCDI_to_CDS(manifest_path: str) -> tuple:
 
     # Quick stats to check the conversion, make sure things are working as we think they should be.
     file_expected = len(
-        df_file.loc[:, ["md5sum", "file_name", "file_url_in_cds"]].drop_duplicates()
+        df_file.loc[:, ["md5sum", "file_name", "file_url"]].drop_duplicates()
     )
     file_returned = len(
-        cds_df.loc[:, ["md5sum", "file_name", "file_url_in_cds"]].drop_duplicates()
+        cds_df.loc[:, ["md5sum", "file_name", "file_url"]].drop_duplicates()
     )
 
     logger.info(

--- a/src/s3_ccdi_to_index.py
+++ b/src/s3_ccdi_to_index.py
@@ -250,8 +250,8 @@ def CCDI_to_IndexeRy(manifest_path: str) -> tuple:
                 node_df.drop(columns=[col_x, col_y], inplace=True)
 
         # clean up the data frame, drop empty columns, rows that don't have files, reset index and remove duplicates.
-        if "file_url_in_cds" in node_df.columns:
-            node_df = node_df.dropna(subset=["file_url_in_cds"])
+        if "file_url" in node_df.columns:
+            node_df = node_df.dropna(subset=["file_url"])
         node_df = node_df.dropna(axis=1, how="all")
         node_df = node_df.reset_index(drop=True)
         node_df = node_df.drop_duplicates()
@@ -750,7 +750,7 @@ def CCDI_to_IndexeRy(manifest_path: str) -> tuple:
         authz = "['/programs/" + authz[2:]
         index_df["authz"] = authz
 
-    simple_add("url", "file_url_in_cds")
+    simple_add("url", "file_url")
 
     # add information for CGC
     # study information
@@ -793,7 +793,7 @@ def CCDI_to_IndexeRy(manifest_path: str) -> tuple:
     simple_add("file_type", "file_type")
     simple_add("file_size", "file_size")
     simple_add("md5sum", "md5sum")
-    simple_add("file_url_in_cds", "file_url_in_cds")
+    simple_add("file_url_in_cds", "file_url")
 
     # library information
     simple_add("library_id", "library_id")
@@ -837,7 +837,7 @@ def CCDI_to_IndexeRy(manifest_path: str) -> tuple:
     simple_add("tumor_stage_clinical_m", "tumor_stage_clinical_m")
 
     # Remove any rows where there is not a file associated with the entry
-    index_df = index_df.dropna(subset=["file_url_in_cds"])
+    index_df = index_df.dropna(subset=["file_url"])
 
     index_df = index_df.drop_duplicates()
 
@@ -878,13 +878,13 @@ def CCDI_to_IndexeRy(manifest_path: str) -> tuple:
     ##############
 
     # Quick stats to check the conversion, make sure things are working as we think they should be.
-    file_total = len(df_file.loc[:, ["md5sum", "file_name", "file_url_in_cds"]])
+    file_total = len(df_file.loc[:, ["md5sum", "file_name", "file_url"]])
 
     file_expected = len(
-        df_file.loc[:, ["md5sum", "file_name", "file_url_in_cds"]].drop_duplicates()
+        df_file.loc[:, ["md5sum", "file_name", "file_url"]].drop_duplicates()
     )
     file_returned = len(
-        index_df.loc[:, ["md5sum", "file_name", "file_url_in_cds"]].drop_duplicates()
+        index_df.loc[:, ["md5sum", "file_name", "file_url"]].drop_duplicates()
     )
     logger.info(
         f"For the following conversion:\n\tUnique files expected: {file_expected}\n\tUnique files returned: {file_returned}"

--- a/src/s3_ccdi_to_sra.py
+++ b/src/s3_ccdi_to_sra.py
@@ -99,7 +99,7 @@ def concat_seq_single_seq(seq_df: DataFrame, single_df: DataFrame) -> DataFrame:
         "number_of_reads",
         "coverage",
         "avg_read_length",
-        "file_url_in_cds",
+        "file_url",
     ]
     seq_df_subset = seq_df[cols_to_keep]
     single_df_subset = single_df[cols_to_keep]
@@ -151,7 +151,7 @@ def trim_seq_df(seq_df: DataFrame) -> DataFrame:
         "number_of_reads",
         "coverage",
         "avg_read_length",
-        "file_url_in_cds",
+        "file_url",
     ]
     seq_df_subset = seq_df[cols_to_keep]
     seq_df_subset["sample_ID"] = seq_df_subset["sample.sample_id"]
@@ -213,7 +213,7 @@ def sra_match_manifest_seq(
     sra_seq_df["coverage"] = manifest_seq_df["coverage"]
     sra_seq_df["AvgReadLength"] = manifest_seq_df["avg_read_length"]
     sra_seq_df["active_location_URL"] = [
-        os.path.dirname(i) + "/" for i in manifest_seq_df["file_url_in_cds"].tolist()
+        os.path.dirname(i) + "/" for i in manifest_seq_df["file_url"].tolist()
     ]
     return sra_seq_df
 

--- a/src/s3_validationry.py
+++ b/src/s3_validationry.py
@@ -710,7 +710,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
         #
         ##############
         # Make one large flattened data frame that contains all files from each node. This will make it easier to not only determine errors, but might catch errors that would not be noticed as they dont exist on the same page.
-        file_nodes = dict_df[dict_df["Property"] == "file_url_in_cds"][
+        file_nodes = dict_df[dict_df["Property"] == "file_url"][
             "Node"
         ].values.tolist()
         file_node_props = [
@@ -718,7 +718,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
             "file_name",
             "file_size",
             "md5sum",
-            "file_url_in_cds",
+            "file_url",
             "node",
         ]
         df_file = pd.DataFrame(columns=file_node_props)
@@ -733,7 +733,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
                 df_file = pd.concat([df_file, df[file_node_props]], ignore_index=True)
 
         # revert HTML code changes that might exist so that it can be handled with correct AWS calls
-        df_file["file_url_in_cds"] = df_file["file_url_in_cds"].map(
+        df_file["file_url"] = df_file["file_url"].map(
             lambda x: (
                 x.replace("%20", " ").replace("%2C", ",").replace("%23", "#")
                 if isinstance(x, str)
@@ -743,7 +743,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
 
         file_ids = df_file["file_id"].dropna().unique().tolist()
         file_names = df_file["file_name"].dropna().unique().tolist()
-        file_urls = df_file["file_url_in_cds"].dropna().unique().tolist()
+        file_urls = df_file["file_url"].dropna().unique().tolist()
 
         ##########################################
         # file metadata checks
@@ -801,7 +801,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
         for file_name in file_names:
             # determine file url
             file_url = df_file[df_file["file_name"] == file_name][
-                "file_url_in_cds"
+                "file_url"
             ].values[0]
             if file_name != os.path.split(os.path.relpath(file_url))[1]:
                 if WARN_FLAG:
@@ -826,7 +826,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
         # for file_name in file_names:
         #     # determine file url
         #     file_url = (
-        #         df_file[df_file["file_name"] == file_name]["file_url_in_cds"]
+        #         df_file[df_file["file_name"] == file_name]["file_url"]
         #         .unique()
         #         .tolist()
         #     )
@@ -846,7 +846,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
         #         # check to see if file_id is unique even if file name isn't
         #         multi_urls = []
         #         for per_file_url in file_url:
-        #             multi_urls = df_file[df_file["file_url_in_cds"] == per_file_url][
+        #             multi_urls = df_file[df_file["file_url"] == per_file_url][
         #                 "file_name"
         #             ].unique().tolist()
         #             print(
@@ -865,7 +865,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
         WARN_FLAG = True
 
         # create bucket column from file data frame
-        df_file["bucket"] = df_file["file_url_in_cds"].str.split("/").str[2]
+        df_file["bucket"] = df_file["file_url"].str.split("/").str[2]
         # print(df_file[df_file.isna().any(axis=1)][["file_name","node","bucket"]].to_markdown())
 
         # return the unique list of buckets
@@ -929,10 +929,10 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
                             file=outf,
                         )
 
-                    current_node = df_file[df_file["file_url_in_cds"] == file_url][
+                    current_node = df_file[df_file["file_url"] == file_url][
                         "node"
                     ].values[0]
-                    file_name = df_file[df_file["file_url_in_cds"] == file_url][
+                    file_name = df_file[df_file["file_url"] == file_url][
                         "file_name"
                     ].values[0]
 
@@ -961,7 +961,7 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
             for file_url in file_urls:
                 if file_url in set(df_bucket["url"]):
                     file_size_test = str(
-                        df_file[df_file["file_url_in_cds"] == file_url]["file_size"]
+                        df_file[df_file["file_url"] == file_url]["file_size"]
                         .unique()
                         .tolist()[0]
                     )
@@ -977,10 +977,10 @@ def ValidationRy(file_path: str, template_path: str):  # removed profile
                                 file=outf,
                             )
 
-                        current_node = df_file[df_file["file_url_in_cds"] == file_url][
+                        current_node = df_file[df_file["file_url"] == file_url][
                             "node"
                         ].values[0]
-                        file_name = df_file[df_file["file_url_in_cds"] == file_url][
+                        file_name = df_file[df_file["file_url"] == file_url][
                             "file_name"
                         ].values[0]
 

--- a/src/template_exampler.py
+++ b/src/template_exampler.py
@@ -81,9 +81,9 @@ def populate_exampler(
                 j_populated_df[m] = [
                     fake_data_generater.get_fake_md5sum() for k in range(entry_count)
                 ]
-            elif m == "file_url_in_cds":
+            elif m == "file_url":
                 j_populated_df[m] = [
-                    fake_data_generater.get_fake_file_url_in_cds(
+                    fake_data_generater.get_fake_file_url(
                         random_words=filter_words
                     )
                     for k in range(entry_count)
@@ -244,7 +244,7 @@ class GetFakeValue:
         two_random_words.append(str(one_random_int))
         return "_".join(two_random_words)
 
-    def get_fake_file_url_in_cds(self, random_words):
+    def get_fake_file_url(self, random_words):
         """Generate fake s3 file url"""
         fake_str = self.get_fake_str(random_words=random_words)
         fake_url = "s3://" + fake_str

--- a/tests/test_file_mover.py
+++ b/tests/test_file_mover.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 from src.file_mover import (
-    parse_file_url_in_cds,
+    parse_file_url,
     dest_object_url,
     compare_md5sum_task,
     copy_object_parameter,
@@ -17,8 +17,8 @@ from src.file_mover import (
 
 
 def test_parse_url():
-    """test for parse_file_url_in_cds()"""
-    bucket_name, object_key = parse_file_url_in_cds(
+    """test for parse_file_url()"""
+    bucket_name, object_key = parse_file_url(
         "s3://mytest-bucket/folder_1/folder2/test_object.fastq"
     )
     assert bucket_name == "mytest-bucket"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,7 +66,7 @@ def fake_sheet_df():
                 "dg.4DFC/guid2",
                 "dg.4DFC/guid3",
             ],
-            "file_url_in_cds": [
+            "file_url": [
                 "s3://some-bucket/testfolder/file1.tsv",
                 "s3://some-bucket/testfolder/file2.tsv",
                 "s3://some-bucket/testfolder/file3.tsv",
@@ -84,7 +84,7 @@ def empty_sheet_df():
             "file_size": [np.nan],
             "md5sum": [np.nan],
             "dcf_indexd_guid": [np.nan],
-            "file_url_in_cds": [np.nan],
+            "file_url": [np.nan],
         }
     )
     return return_df

--- a/tests/test_validationry_refactored.py
+++ b/tests/test_validationry_refactored.py
@@ -345,7 +345,7 @@ def test_count_buckets():
     test_df = pd.DataFrame(
         {
             "type": ["test_type"] * 4,
-            "file_url_in_cds": [
+            "file_url": [
                 "s3://bucket1/folder/file1",
                 "s3://bucket1/folder/file2",
                 "s3://bucket2/folder/file1",

--- a/workflows/guid_checker.py
+++ b/workflows/guid_checker.py
@@ -30,7 +30,7 @@ def pull_guids(row):
     hash_value = row["md5sum"]
     size = row["file_size"]
     guid = row["dcf_indexd_guid"]
-    file_url = row["file_url_in_cds"]
+    file_url = row["file_url"]
     file_name = os.path.basename(file_url)
     file_path = os.path.dirname(file_url)
 
@@ -170,7 +170,7 @@ def guid_checker(file_path: str):  # removed profile
     guidcheck_logger.info("Calling Indexd API")
 
     for node in dict_nodes:
-        if "file_url_in_cds" in meta_dfs[node].columns:
+        if "file_url" in meta_dfs[node].columns:
             guidcheck_logger.info(f"Checking {node}.")
             df = meta_dfs[node]
 

--- a/workflows/mci_release_run.py
+++ b/workflows/mci_release_run.py
@@ -12,7 +12,7 @@ from src.mci_monthly_release import (
     MCIInputDescriptionMD,
 )
 from src.utils import file_dl, CCDI_Tags, get_time, file_ul, get_date
-from src.file_mover import parse_file_url_in_cds
+from src.file_mover import parse_file_url
 from src.submission_cruncher import concatenate_submissions
 
 
@@ -26,7 +26,7 @@ def mci_release_manifest(
 ):
     logger = get_run_logger()
 
-    manifest_bucket, manifest_folder = parse_file_url_in_cds(
+    manifest_bucket, manifest_folder = parse_file_url(
         url=mci_manifests_bucket_path
     )
     logger.info(


### PR DESCRIPTION
The main edits were replacing the phrase "file_url_in_cds" with just "file_url", except in cases where there was a lift-over to CDS and the property is still called "file_url_in_cds".