### PR TITLE
CCDIDC-1206 dcf index update

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1166,7 +1166,7 @@ def extract_dcf_index_single_sheet(
     The task returns a dictionary of lists
 
     This function is compatible for ccdi data model 1.9.0 and after
-    All fille node will have "acl" and "authz properties
+    All file nodes will have "acl" and "authz" properties
     The return df will have 8 cols, "guid", "md5sum", "urls", "size", "node", 
     "if_guid_missing", "acl", "authz" 
     """

--- a/workflows/dcf_indexing.py
+++ b/workflows/dcf_indexing.py
@@ -46,8 +46,6 @@ def dcf_index_manifest(
 
     # extract study accession of the manifest
     study_accession = manifest_obj.get_study_id()
-    acl = f"['{study_accession}']"
-    authz = f"['/programs/{study_accession}']"
     logger.info(f"Study accesion: {study_accession}")
 
     # find the data file sheets/nodes
@@ -89,9 +87,8 @@ def dcf_index_manifest(
 
     # finish up with the dcf index df
     combined_df.drop(columns=["node","if_guid_missing"], inplace=True)
-    combined_df["acl"] = acl
-    combined_df["authz"] = authz
-    col_order = ["GUID", "md5", "size", "acl", "authz", "urls"]
+    combined_df["phs_accession"] = study_accession
+    col_order = ["guid", "md5", "size", "acl", "authz", "urls", "phs_accession"]
     combined_df = combined_df[col_order]
 
     # save df to tsv and upload to bucket


### PR DESCRIPTION
Added Feature

- Pipeline was modified to accommodate the new `acl` and `authz` at file level instead of study level.
- The pipeline now only works for model version 1.8.0 and above, since `file level acl and authz` were missing before that version