### PR TITLE
CCDIDC 1266 validation key id bug

### DIFF
--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -735,6 +735,8 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     # read dict_df
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
     print(dict_df)
+    print(dict_df.columns)
+    print(dict_df[dict_df["Node"]==node_name][["Property", "Node", "Required", "Key"]])
     # pull out all key value properties
     key_value_props = dict_df.loc[
         (dict_df["Key"] == True) & (dict_df["Node"] == node_name), "Property"

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -730,14 +730,10 @@ def validate_regex(
 )
 def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     node_df = file_object.read_sheet_na(sheetname=node_name)
-    print(node_name)
 
     # read dict_df
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
-    print(dict_df)
-    print(dict_df.columns)
-    print(dict_df[dict_df["Node"]==node_name][["Property", "Node", "Required", "Key"]])
-    print(dict_df[dict_df["Node"] == node_name]["Key"].dropna().tolist())
+    dict_df["Key"] = dict_df["Key"].str.upper()
     # pull out all key value properties
     key_value_props = dict_df.loc[
         (dict_df["Key"] == "TRUE") & (dict_df["Node"] == node_name), "Property"
@@ -806,6 +802,7 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
         print_str = (
             print_str + f"WARNING: node {node_name} file contains no Key id property\n"
         )
+    print(print_str)
     return print_str
 
 
@@ -1433,9 +1430,14 @@ def validate_key_id_single_sheet(node_name: str, file_object, template_object) -
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
     # pull out all the id properties in the node
     id_props = node_df.filter(like="_id", axis=1).columns.tolist()
-    key_id_props = dict_df[dict_df["Key"] == "True"]["Property"].unique().tolist()
+    print(id_props)
+    # convert values under "Key" column to uppercase
+    dict_df["Key"] = dict_df["Key"].str.upper()
+    key_id_props = dict_df[dict_df["Key"] == "TRUE"]["Property"].unique().tolist()
+    print(key_id_props)
     # pull out only the key ids that are present in the node
     key_ids = list(set(id_props) & set(key_id_props))
+    print(key_ids)
 
     check_list = []
     for key_id in key_ids:

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -738,7 +738,6 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     key_value_props = dict_df.loc[
         (dict_df["Key"] == "TRUE") & (dict_df["Node"] == node_name), "Property"
     ].tolist()
-    print(key_value_props)
 
     print_str = f"\n\t{node_name}\n\t----------\n\t"
     check_list = []
@@ -762,7 +761,6 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
                         property_dict["check"] = "ERROR"
                         # create a tavle of values and counts
                         freq_key_values = node_df[key_value_prop].value_counts()
-                        print(freq_key_values)
                         # pull out a unique list of values that have more than one instance
                         not_unique_key_values = (
                             node_df[
@@ -802,7 +800,6 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
         print_str = (
             print_str + f"WARNING: node {node_name} file contains no Key id property\n"
         )
-    print(print_str)
     return print_str
 
 
@@ -1430,14 +1427,11 @@ def validate_key_id_single_sheet(node_name: str, file_object, template_object) -
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
     # pull out all the id properties in the node
     id_props = node_df.filter(like="_id", axis=1).columns.tolist()
-    print(id_props)
     # convert values under "Key" column to uppercase
     dict_df["Key"] = dict_df["Key"].str.upper()
     key_id_props = dict_df[dict_df["Key"] == "TRUE"]["Property"].unique().tolist()
-    print(key_id_props)
     # pull out only the key ids that are present in the node
     key_ids = list(set(id_props) & set(key_id_props))
-    print(key_ids)
 
     check_list = []
     for key_id in key_ids:
@@ -1560,19 +1554,6 @@ def ValidationRy_new(file_path: str, template_path: str):
     )
     validation_logger.info(f"Nodes will be validated: {*nodes_to_validate,}")
 
-    # validate unique keys
-    validation_logger.info("Checking unique keys")
-    validate_unique_key(nodes_to_validate, file_path, template_path, output_file)
-
-    # validate key id pattern
-    validation_logger.info("Checking key id patterns")
-    validate_key_id(
-        file_path=file_path,
-        template_path=template_path,
-        node_list=nodes_to_validate,
-        output_file=output_file,
-    )
-
     # starts validation of unempty node sheets
     validation_logger.info("Checking if required properties were filled")
     validate_required_properties(
@@ -1600,6 +1581,10 @@ def ValidationRy_new(file_path: str, template_path: str):
     validation_logger.info("Checking regular expression")
     validate_regex(nodes_to_validate, file_path, template_path, output_file)
 
+    # validate unique keys
+    validation_logger.info("Checking unique keys")
+    validate_unique_key(nodes_to_validate, file_path, template_path, output_file)
+
     # validate file metadata (size, md5sum regex, and file basename in url)
     validation_logger.info(
         "Checking object file metadata, size, md5sum regex, and file basename"
@@ -1611,7 +1596,6 @@ def ValidationRy_new(file_path: str, template_path: str):
         output_file=output_file,
     )
 
-    """
     # validate bucket content
     validation_logger.info("Checking bucket contents against manifest file objects")
     validate_bucket_content(
@@ -1620,12 +1604,20 @@ def ValidationRy_new(file_path: str, template_path: str):
         template_path=template_path,
         output_file=output_file,
     )
-    """
 
     # validate cross links
     validation_logger.info("Checking cross links between nodes")
     validate_cross_links(
         node_list=nodes_to_validate, file_path=file_path, output_file=output_file
+    )
+
+    # validate key id pattern
+    validation_logger.info("Checking key id patterns")
+    validate_key_id(
+        file_path=file_path,
+        template_path=template_path,
+        node_list=nodes_to_validate,
+        output_file=output_file,
     )
 
     validation_logger.info(

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -736,9 +736,9 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
     print(dict_df)
     # pull out all key value properties
-    key_value_props = dict_df[
-        (dict_df["Key"] == True) & (dict_df["Node"] == node_name)
-    ]["Property"].values
+    key_value_props = dict_df.loc[
+        (dict_df["Key"] == True) & (dict_df["Node"] == node_name), "Property"
+    ].tolist()
     print(key_value_props)
 
     print_str = f"\n\t{node_name}\n\t----------\n\t"

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -1555,6 +1555,10 @@ def ValidationRy_new(file_path: str, template_path: str):
     )
     validation_logger.info(f"Nodes will be validated: {*nodes_to_validate,}")
 
+    # validate unique keys
+    validation_logger.info("Checking unique keys")
+    validate_unique_key(nodes_to_validate, file_path, template_path, output_file)
+    
     # starts validation of unempty node sheets
     validation_logger.info("Checking if required properties were filled")
     validate_required_properties(
@@ -1581,10 +1585,6 @@ def ValidationRy_new(file_path: str, template_path: str):
     # validate regex
     validation_logger.info("Checking regular expression")
     validate_regex(nodes_to_validate, file_path, template_path, output_file)
-
-    # validate unique keys
-    validation_logger.info("Checking unique keys")
-    validate_unique_key(nodes_to_validate, file_path, template_path, output_file)
 
     # validate file metadata (size, md5sum regex, and file basename in url)
     validation_logger.info(

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -737,6 +737,7 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     print(dict_df)
     print(dict_df.columns)
     print(dict_df[dict_df["Node"]==node_name][["Property", "Node", "Required", "Key"]])
+    print(dict_df[dict_df["Node"] == node_name]["Key"].dropna().tolist())
     # pull out all key value properties
     key_value_props = dict_df.loc[
         (dict_df["Key"] == True) & (dict_df["Node"] == node_name), "Property"

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -733,10 +733,12 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
 
     # read dict_df
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
+    print(dict_df)
     # pull out all key value properties
     key_value_props = dict_df[
         (dict_df["Key"] == "True") & (dict_df["Node"] == node_name)
     ]["Property"].values
+    print(key_value_props)
 
     print_str = f"\n\t{node_name}\n\t----------\n\t"
     check_list = []

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -730,13 +730,14 @@ def validate_regex(
 )
 def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     node_df = file_object.read_sheet_na(sheetname=node_name)
+    print(node_name)
 
     # read dict_df
     dict_df = template_object.read_sheet_na(sheetname="Dictionary")
     print(dict_df)
     # pull out all key value properties
     key_value_props = dict_df[
-        (dict_df["Key"] == "True") & (dict_df["Node"] == node_name)
+        (dict_df["Key"] == True) & (dict_df["Node"] == node_name)
     ]["Property"].values
     print(key_value_props)
 

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -1591,6 +1591,7 @@ def ValidationRy_new(file_path: str, template_path: str):
         output_file=output_file,
     )
 
+    """
     # validate bucket content
     validation_logger.info("Checking bucket contents against manifest file objects")
     validate_bucket_content(
@@ -1599,6 +1600,7 @@ def ValidationRy_new(file_path: str, template_path: str):
         template_path=template_path,
         output_file=output_file,
     )
+    """
 
     # validate cross links
     validation_logger.info("Checking cross links between nodes")

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -740,7 +740,7 @@ def validate_unique_key_one_sheet(node_name: str, file_object, template_object):
     print(dict_df[dict_df["Node"] == node_name]["Key"].dropna().tolist())
     # pull out all key value properties
     key_value_props = dict_df.loc[
-        (dict_df["Key"] == True) & (dict_df["Node"] == node_name), "Property"
+        (dict_df["Key"] == "TRUE") & (dict_df["Node"] == node_name), "Property"
     ].tolist()
     print(key_value_props)
 

--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -1443,15 +1443,16 @@ def validate_key_id_single_sheet(node_name: str, file_object, template_object) -
     for key_id in key_ids:
         # find the unique values of that linking property
         id_values = node_df[key_id].dropna().unique().tolist()
-
-        # if there are values with ";", unpack them
-        # for instance ["apple;orange", "milk;yogurt", "cabbage;carrot"] -> ['apple', 'orange', 'milk', 'yogurt', 'cabbage', 'carrot']
+        # if that key id column is not empty
         if len(id_values) > 0:
             property_dict = {}
             property_dict["node"] = node_name
+            property_dict["property"] = key_id
             # if there is an array of link values, pull the array apart and delete the old value.
             remove_id_value = []
             append_id_value = []
+            # if there are values with ";", unpack them
+            # for instance ["apple;orange", "milk;yogurt", "cabbage;carrot"] -> ['apple', 'orange', 'milk', 'yogurt', 'cabbage', 'carrot']
             for id_value in id_values:
                 if ";" in id_value:
                     value_splits = str.split(id_value, ";")
@@ -1474,9 +1475,11 @@ def validate_key_id_single_sheet(node_name: str, file_object, template_object) -
             if len(troubled_id_value) > 0:
                 property_dict["check"] = "ERROR\nillegal character"
                 property_dict["error value"] = ",".join(troubled_id_value)
-                check_list.append(property_dict)
+                
             else:
-                pass
+                property_dict["check"] = "PASS"
+                property_dict["error value"] = ""
+            check_list.append(property_dict)
         else:
             pass
     check_df = pd.DataFrame.from_records(check_list)
@@ -1560,7 +1563,16 @@ def ValidationRy_new(file_path: str, template_path: str):
     # validate unique keys
     validation_logger.info("Checking unique keys")
     validate_unique_key(nodes_to_validate, file_path, template_path, output_file)
-    
+
+    # validate key id pattern
+    validation_logger.info("Checking key id patterns")
+    validate_key_id(
+        file_path=file_path,
+        template_path=template_path,
+        node_list=nodes_to_validate,
+        output_file=output_file,
+    )
+
     # starts validation of unempty node sheets
     validation_logger.info("Checking if required properties were filled")
     validate_required_properties(
@@ -1614,15 +1626,6 @@ def ValidationRy_new(file_path: str, template_path: str):
     validation_logger.info("Checking cross links between nodes")
     validate_cross_links(
         node_list=nodes_to_validate, file_path=file_path, output_file=output_file
-    )
-
-    # validate key id pattern
-    validation_logger.info("Checking key id patterns")
-    validate_key_id(
-        file_path=file_path,
-        template_path=template_path,
-        node_list=nodes_to_validate,
-        output_file=output_file,
     )
 
     validation_logger.info(

--- a/tests/test_validationry_refactored.py
+++ b/tests/test_validationry_refactored.py
@@ -337,7 +337,7 @@ def test_validate_key_id_single_sheet(datafiles):
     print_str = validate_key_id_single_sheet.fn(
         node_name="pdx", file_object=file_object, template_object=temp_object
     )
-    assert print_str.count("pdx") == 2
+    assert print_str.count("pdx") == 3
     assert "diligent_overwrought_80&" in print_str
 
 

--- a/tests/test_validationry_refactored.py
+++ b/tests/test_validationry_refactored.py
@@ -230,7 +230,7 @@ def test_validate_integer_numeric_checks_one_sheet(datafiles):
 
 @ALL_FILES
 def test_validate_unique_key_one_sheet(datafiles):
-    """test for validate_integer_numeric_checks_one_sheet task"""
+    """test for validate_unique_key_one_sheet task"""
     for item in datafiles.iterdir():
         if "Exampler" in item.name:
             file_path = str(item)


### PR DESCRIPTION
Fixed bug

- The bug was caused by the failure of subsetting`Dictionary` dataframe using `Key` value == True. The fix is to convert the value to uppercase and force the selected value to be `TRUE`
- Both validations of `unique key` and `key id`  were modified, as well as unittests 