### PR TITLE
CCDIDC-1334 SRA: create new library id when multiple active location URLs are found

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -750,3 +750,31 @@ deployments:
       name: ccdi-curation-32gb
       work_queue_name: null
       job_variables: {}
+
+  - name: ccdi-to-sra
+    version: null
+    tags: ["TEST"]
+    description: null
+    entrypoint: workflows/ccdi_to_sra.py:run_ccdi_to_sra
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.projects.steps.git_clone_project:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: CCDIDC-1334_sra_library_id
+      - prefect.projects.steps.pip_install_requirements:
+          requirements_file: requirements.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-curation-60gb
+      work_queue_name: null
+      job_variables: {}

--- a/src/s3_ccdi_to_sra.py
+++ b/src/s3_ccdi_to_sra.py
@@ -1198,7 +1198,7 @@ def concatenate_library_id(sra_df: DataFrame) -> DataFrame:
 
     Note:
     If more than one active location url value is found, new library_id should be
-    created for each unique active_location_url
+    created for each unique active_location_URL
     """
     sra_df["check_sample_id"] = (
         sra_df["sample_ID"]
@@ -1222,17 +1222,17 @@ def concatenate_library_id(sra_df: DataFrame) -> DataFrame:
 
         # check for rows of sra_df["check_sample_id"] == i, if more than one active_location_url are found
         # at this point, subset of sra_df["check_sample_id"] == i should be sharing the same library_id
-        if len(i_df["active_location_url"].dropna().unique().tolist()) > 1:
+        if len(i_df["active_location_URL"].dropna().unique().tolist()) > 1:
             # the library_id for the subset of sra_df[sra_df["check_sample_id"] == i]
             # all library_id should be the same for the subset
             i_library_id = sra_df[sra_df["check_sample_id"] == i]["library_ID"].tolist()[0]
             # loop through each unique location
             loc_count = 1
-            for j_loc in i_df["active_location_url"].dropna().unique().tolist():
+            for j_loc in i_df["active_location_URL"].dropna().unique().tolist():
                 # rename the library_id to be <original_library_id>_<number>
                 sra_df.loc[
                     (sra_df["check_sample_id"] == i)
-                    & (sra_df["active_location_url"] == j_loc),
+                    & (sra_df["active_location_URL"] == j_loc),
                     "library_ID",
                 ] = i_library_id + "_" + str(loc_count)
                 loc_count += 1

--- a/src/s3_ccdi_to_sra.py
+++ b/src/s3_ccdi_to_sra.py
@@ -1195,6 +1195,10 @@ def concatenate_library_id(sra_df: DataFrame) -> DataFrame:
 
     So in the spread_sra_df step, files from the library_a;library_b will be
     transformed into a single line
+
+    Note:
+    If more than one active location url value is found, new library_id should be
+    created for each unique active_location_url
     """
     sra_df["check_sample_id"] = (
         sra_df["sample_ID"]
@@ -1207,11 +1211,34 @@ def concatenate_library_id(sra_df: DataFrame) -> DataFrame:
     for i in unique_concate:
         i_df = sra_df[sra_df["check_sample_id"] == i]
         # concatenate library_ID if more than one unqiue library_ID are found
+        # at this point, library_ID has been changed if more than one library_id has been found
+        # sharing the same sample_id, library_strategy, library_source, and library_seleciton
         if len(i_df["library_ID"].dropna().unique().tolist()) > 1:
             i_library_id = ";".join(i_df["library_ID"].dropna().unique().tolist())
             sra_df.loc[sra_df["check_sample_id"] == i, "library_ID"] = i_library_id
         else:
+            # if only one library_id found, no change made to library_id
             pass
+
+        # check for rows of sra_df["check_sample_id"] == i, if more than one active_location_url are found
+        # at this point, subset of sra_df["check_sample_id"] == i should be sharing the same library_id
+        if len(i_df["active_location_url"].dropna().unique().tolist()) > 1:
+            # the library_id for the subset of sra_df[sra_df["check_sample_id"] == i]
+            # all library_id should be the same for the subset
+            i_library_id = sra_df[sra_df["check_sample_id"] == i]["library_ID"].tolist()[0]
+            # loop through each unique location
+            loc_count = 1
+            for j_loc in i_df["active_location_url"].dropna().unique().tolist():
+                # rename the library_id to be <original_library_id>_<number>
+                sra_df.loc[
+                    (sra_df["check_sample_id"] == i)
+                    & (sra_df["active_location_url"] == j_loc),
+                    "library_ID",
+                ] = i_library_id + "_" + str(loc_count)
+                loc_count += 1
+        else:
+            pass
+
         # concatenate design description if more than one unqiue description are found
         if len(i_df["design_description"].dropna().unique().tolist()) > 1:
             i_design_description = ";".join(
@@ -1255,17 +1282,7 @@ def concatenate_library_id(sra_df: DataFrame) -> DataFrame:
             ] = i_alignment_software
         else:
             pass
-        # concatenate active location url if more than one unique value were found
-        if len(i_df["active_location_URL"].dropna().unique().tolist()) > 1:
-            i_active_url = ";".join(
-                i_df["active_location_URL"].dropna().unique().tolist()
-            )
-            sra_df.loc[
-                sra_df["check_sample_id"] == i,
-                "active_location_URL",
-            ] = i_active_url
-        else:
-            pass
+
     sra_df = sra_df.drop(columns=["check_sample_id"])
     return sra_df
 


### PR DESCRIPTION
Added patch

- Create new library id when more than one active location urls associated with the same library id were found
- new library id would be [old_library_id]_[number]