### PR TITLE
CCDIDC 1727 gdc import

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2051,7 +2051,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: CCDIDC-1727_gdc_import
+          branch: main
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_V3.txt
           directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2051,7 +2051,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: main
+          branch: CCDIDC-1727_gdc_import
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_V3.txt
           directory: "{{ clone-step.directory }}"

--- a/requirements_V3.txt
+++ b/requirements_V3.txt
@@ -1,5 +1,6 @@
 boto3==1.37.32
 botocore==1.37.32
+deepdiff==8.0.1
 graphql-core==3.2.6
 greenlet==3.1.1
 h2==4.2.0

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -456,7 +456,6 @@ def entity_parser(node: dict):
 
     return node
 
-@task(name="gdc_import_json_compare", log_prints=True)
 def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
     """Compare node entity metadata; if node in submission file is different than in GDC
     then slate for import, otherwise ignore; use DeepDiff for comparison
@@ -469,15 +468,14 @@ def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
         bool: Indication if metadata in file is different from what metadata has been submitted to GDC
     """
 
-    #extract only properties found in submission node from gdc node
+    #extract only properties found in submission node from gdc node to perform comparison
+    #in order to exclude added on, non-required props from GDC
     gdc_node_metadata_parse = {}
     for key in submit_file_metadata.keys():
         if key in gdc_node_metadata.keys():
             gdc_node_metadata_parse[key] = gdc_node_metadata[key]
 
     if DeepDiff(submit_file_metadata, gdc_node_metadata_parse, ignore_order=True):
-        print(submit_file_metadata)
-        print(gdc_node_metadata_parse)
         return True
     else:
         return False

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -469,9 +469,15 @@ def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
         bool: Indication if metadata in file is different from what metadata has been submitted to GDC
     """
 
-    if DeepDiff(submit_file_metadata, gdc_node_metadata, ignore_order=True):
+    #extract only properties found in submission node from gdc node
+    gdc_node_metadata_parse = {}
+    for key in submit_file_metadata.keys():
+        if key in gdc_node_metadata.keys():
+            gdc_node_metadata_parse[key] = gdc_node_metadata[key]
+
+    if DeepDiff(submit_file_metadata, gdc_node_metadata_parse, ignore_order=True):
         print(submit_file_metadata)
-        print(gdc_node_metadata)
+        print(gdc_node_metadata_parse)
         return True
     else:
         return False

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 import boto3
 from botocore.exceptions import ClientError
-from prefect import flow, get_run_logger
+from prefect import flow,task, get_run_logger
 from src.utils import get_time, file_dl, folder_ul, sanitize_return, get_secret
 
 
@@ -456,7 +456,7 @@ def entity_parser(node: dict):
 
     return node
 
-
+@task(name="gdc_import_json_compare", log_prints=True)
 def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
     """Compare node entity metadata; if node in submission file is different than in GDC
     then slate for import, otherwise ignore; use DeepDiff for comparison
@@ -470,6 +470,8 @@ def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
     """
 
     if DeepDiff(submit_file_metadata, gdc_node_metadata, ignore_order=True):
+        print(submit_file_metadata)
+        print(gdc_node_metadata)
         return True
     else:
         return False

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -254,8 +254,6 @@ def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: st
 
     runner_logger = get_run_logger()
 
-    token = get_secret(secret_name_path, secret_key_name).strip()
-
     offset_returns = []
     endpt = "https://api.gdc.cancer.gov/submission/graphql"
     null = ""  # None
@@ -298,7 +296,7 @@ def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: st
             runner_logger.error(
                 f" Response is malformed: {str(response.text)} for query {str(query2)}, trying again..."  # loads > dumps
             )
-            response = make_request("post", endpt, token, req_data=query2)
+            response = make_request("post", endpt, secret_name_path, secret_key_name, req_data=query2)
 
         # check if anymore hits, if not break to speed up process
 
@@ -365,7 +363,7 @@ def query_entities(node_uuids: list, project_id: str, secret_name_path: str, sec
             retries = 0
             while retries < max_retries:
                 try:
-                    temp = make_request('get', api + uuids_fmt, token) #make request
+                    temp = make_request('get', api + uuids_fmt, secret_name_path, secret_key_name) #make request
                     entities = json.loads(temp.text)["entities"] #extract entities from request
                     retries = max_retries #update retries counter to exit loop
                 except:
@@ -708,7 +706,8 @@ def submit(nodes: list, project_id: str, secret_name_path: str, secret_key_name:
             for node in nodes:
                 res = make_request("post",
                     api,
-                    token,
+                    secret_name_path,
+                    secret_key_name
                     req_data=node
                 )
 
@@ -721,7 +720,8 @@ def submit(nodes: list, project_id: str, secret_name_path: str, secret_key_name:
             for node in nodes:
                 res = make_request("put",
                     api,
-                    token,
+                    secret_name_path,
+                    secret_key_name
                     req_data=node
                 )
 

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -707,7 +707,7 @@ def submit(nodes: list, project_id: str, secret_name_path: str, secret_key_name:
                 res = make_request("post",
                     api,
                     secret_name_path,
-                    secret_key_name
+                    secret_key_name,
                     req_data=node
                 )
 
@@ -721,7 +721,7 @@ def submit(nodes: list, project_id: str, secret_name_path: str, secret_key_name:
                 res = make_request("put",
                     api,
                     secret_name_path,
-                    secret_key_name
+                    secret_key_name,
                     req_data=node
                 )
 

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -288,7 +288,7 @@ def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: st
         query2 = {"query": query1, "variables": null}
 
         # retrieve response
-        response = make_request("post", endpt, token, req_data=query2)
+        response = make_request("post", endpt, secret_name_path, secret_key_name, req_data=query2)
 
         # check if malformed
         try:

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 import boto3
 from botocore.exceptions import ClientError
-from prefect import flow,task, get_run_logger
+from prefect import flow, task, get_run_logger
 from src.utils import get_time, file_dl, folder_ul, sanitize_return, get_secret
 
 
@@ -798,9 +798,6 @@ def runner(
 
     # check the manifest version before the workflow starts
     file_name = os.path.basename(file_path)
-
-    # get token
-    #token = get_secret(secret_name_path, secret_key_name).strip()
 
     # load in nodes file
     nodes = loader(file_name, node_type)

--- a/workflows/gdc_import.py
+++ b/workflows/gdc_import.py
@@ -50,7 +50,7 @@ def read_json(dir_path: str):
 
     return nodes
 
-
+@task(name="gdc_import_loader", log_prints=True)
 def loader(dir_path: str, node_type: str):
     """Checks that JSON file is a list of dicts and all nodes are of expected type and node type.
 
@@ -234,7 +234,7 @@ def dbgap_compare(phs_id_version: str, nodes: list):
 
     return parsed_subjects
 
-
+@task(name="gdc_import_retrieve_current_nodes", log_prints=True)
 def retrieve_current_nodes(project_id: str, node_type: str, token: str):
     """Query and return all nodes already submitted to GDC for project and node type
 
@@ -480,7 +480,7 @@ def json_compare(submit_file_metadata: dict, gdc_node_metadata: dict):
     else:
         return False
 
-
+@flow(name="gdc_import_compare_diff", log_prints=True)
 def compare_diff(nodes: list, project_id: str, node_type: str, token: str, check_for_updates: str):
     """Determine if nodes in submission file are new entities or already exist in GDC
 


### PR DESCRIPTION
update gdc-import workflow (node metadata submission to GDC) for prefect V3

additional updates:

-     changed passing token to flows/tasks instead to passing secrets parameters to pull cred (additional layer of security)
-     add more flow and task decorators for visualization
-     better handling for node entity comparison (new vs. already submitted in GDC) to avoid redundant submissions of same data

