### PR TITLE
CCDIDC 1644 gdc upload

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1020,6 +1020,7 @@ deployments:
       project_id: "CCDI-MCI"
       manifest_path: ""
       gdc_client_path: "bullenca/file_upload_test/gdc-client"
+      node_type: "submitted_aligned_reads"
       runner: ""
       secret_name_path: "ccdi/nonprod/inventory/gdc-token"
       secret_key_name: "gdc-token"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2078,6 +2078,7 @@ deployments:
       project_id: "CCDI-MCI"
       manifest_path: ""
       gdc_client_path: "bullenca/file_upload_test/gdc-client"
+      node_type: "submitted_aligned_reads"
       runner: ""
       secret_name_path: "ccdi/nonprod/inventory/gdc-token"
       secret_key_name: "gdc-token"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2092,7 +2092,7 @@ deployments:
     - prefect.deployments.steps.git_clone:
         id: clone-step
         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-        branch: CCDIDC-1644_gdc_upload
+        branch: main
     - prefect.deployments.steps.pip_install_requirements:
         requirements_file: requirements_V3.txt
         directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2092,7 +2092,7 @@ deployments:
     - prefect.deployments.steps.git_clone:
         id: clone-step
         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-        branch: main
+        branch: CCDIDC-1644_gdc_upload
     - prefect.deployments.steps.pip_install_requirements:
         requirements_file: requirements_V3.txt
         directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1020,7 +1020,6 @@ deployments:
       project_id: "CCDI-MCI"
       manifest_path: ""
       gdc_client_path: "bullenca/file_upload_test/gdc-client"
-      node_type: "submitted_aligned_reads"
       runner: ""
       secret_name_path: "ccdi/nonprod/inventory/gdc-token"
       secret_key_name: "gdc-token"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2091,7 +2091,7 @@ deployments:
     - prefect.deployments.steps.git_clone:
         id: clone-step
         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-        branch: CCDIDC-1644_gdc_upload
+        branch: main
     - prefect.deployments.steps.pip_install_requirements:
         requirements_file: requirements_V3.txt
         directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2091,7 +2091,7 @@ deployments:
     - prefect.deployments.steps.git_clone:
         id: clone-step
         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-        branch: main
+        branch: CCDIDC-1644_gdc_upload
     - prefect.deployments.steps.pip_install_requirements:
         requirements_file: requirements_V3.txt
         directory: "{{ clone-step.directory }}"

--- a/src/gdc_utils.py
+++ b/src/gdc_utils.py
@@ -114,7 +114,7 @@ def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: st
             + str(n_query)
             + ", offset:"
             + str(offset)
-            + "){\n\t\tsubmitter_id\n\t\tid\n\t\tfile_siz\n\t\tfile_name\n\t\tmd5sum\n\t\tfile_state\n\t\tstate\n\t}\n}"
+            + "){\n\t\tsubmitter_id\n\t\tid\n\t\tfile_size\n\t\tfile_name\n\t\tmd5sum\n\t\tfile_state\n\t\tstate\n\t}\n}"
         )
         query2 = {"query": query1, "variables": null}
 

--- a/src/gdc_utils.py
+++ b/src/gdc_utils.py
@@ -70,7 +70,7 @@ def make_request(req_type: str, url: str, secret_name_path: str, secret_key_name
     runner_logger.error(f"Max retries reached. {req_type.upper()} request {url} failed.")
     return str(e)
 
-@task(name="gdc_retrieve_current_nodes", log_prints=True)
+@flow(name="gdc_retrieve_current_nodes", log_prints=True)
 def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: str, secret_key_name: str):
     """Query and return all nodes already submitted to GDC for project and node type
 

--- a/src/gdc_utils.py
+++ b/src/gdc_utils.py
@@ -114,7 +114,7 @@ def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: st
             + str(n_query)
             + ", offset:"
             + str(offset)
-            + "){\n\t\tsubmitter_id\n\t\tid\n\t\tfile_size\n\t\tmd5sum\n\t\tfile_state\n\t\tstate\n\t}\n}"
+            + "){\n\t\tsubmitter_id\n\t\tid\n\t\tfile_siz\n\t\tfile_name\n\t\tmd5sum\n\t\tfile_state\n\t\tstate\n\t}\n}"
         )
         query2 = {"query": query1, "variables": null}
 

--- a/src/gdc_utils.py
+++ b/src/gdc_utils.py
@@ -1,0 +1,148 @@
+# gdc utils
+from prefect import flow, task, get_run_logger
+import sys
+import pandas as pd
+import json
+import requests
+import time
+from src.utils import get_time, file_dl, folder_ul, get_secret
+
+def make_request(req_type: str, url: str, secret_name_path: str, secret_key_name: str, req_data="", max_retries=5, delay=2):
+    """Wrapper for request function to handle request retries for timeouts and connection errors
+
+    Args:
+        req_type (str): Type of request (GET, PUT or POST)
+        url (str): API URL to make request to
+        secret_name_path (str): Path to AWS secrets manager where token hash stored
+        secret_key_name (str): Authentication token string secret key name for GDC submission
+        data (dict, optional): JSON formatted data. Defaults to {} (no data).
+        max_retries (int, optional): _description_. Defaults to 3.
+        delay (int, optional): _description_. Defaults to 10.
+
+    Returns:
+        str: Request response
+    """
+    runner_logger = get_run_logger()
+
+    token = get_secret(secret_name_path, secret_key_name).strip()
+    
+    retries = 0
+
+    # for GET requests
+    if req_type.upper() == 'GET':
+        while retries < max_retries:
+            try:
+                if req_data == "":
+                    response = requests.get(url, headers={"X-Auth-Token": token})
+                    return response
+                else:
+                    response = requests.get(url, json=req_data, headers={"X-Auth-Token": token, "Content-Type": "application/json"})
+                    return response
+            except Exception as e:
+                runner_logger.warning(f"Error with request: {e}. Retrying...")
+                retries += 1
+                time.sleep(delay)
+    # for POST requests
+    elif req_type.upper() == 'POST':
+        while retries < max_retries:
+            try:
+                response = requests.post(url, json=req_data, headers={"X-Auth-Token": token, "Content-Type": "application/json"})
+                return response
+            except Exception as e:
+                runner_logger.warning(f"Error with request: {e}. Retrying...")
+                retries += 1
+                time.sleep(delay)
+    # for PUT requests
+    elif req_type.upper() == 'PUT':
+        while retries < max_retries:
+            try:
+                response = requests.put(url, json=req_data, headers={"X-Auth-Token": token, "Content-Type": "application/json"})
+                return response
+            except Exception as e:
+                runner_logger.warning(f"Error with request: {e}. Retrying...")
+                retries += 1
+                time.sleep(delay)
+    else:
+        runner_logger.error(f"{req_type} not one of ['GET', 'POST', 'PUT']")
+        sys.exit(1)
+
+
+    runner_logger.error(f"Max retries reached. {req_type.upper()} request {url} failed.")
+    return str(e)
+
+@task(name="gdc_retrieve_current_nodes", log_prints=True)
+def retrieve_current_nodes(project_id: str, node_type: str, secret_name_path: str, secret_key_name: str):
+    """Query and return all nodes already submitted to GDC for project and node type
+
+    Args:
+        project_id (str): Project ID to submit node metadata for
+        node_type (str): Node type for nodes to submit
+        secret_name_path (str): Path to AWS secrets manager where token hash stored
+        secret_key_name (str): Authentication token string secret key name for GDC submission
+
+    Returns:
+        list: List of dict node metadata that has already been submitted successfully to GDC
+    """
+
+
+    runner_logger = get_run_logger()
+
+    offset_returns = []
+    endpt = "https://api.gdc.cancer.gov/submission/graphql"
+    null = ""  # None
+
+    # need to do run queries 500 at a time to avoid time outs
+    # may need to increase max number to avoid missing data if more data added in future
+
+    # number nodes to query
+    n_query = 500
+
+    for offset in range(0, 500000, n_query):
+        time.sleep(2)
+        # print to runner_logger that running query
+        runner_logger.info(
+            f" Checking for {node_type} nodes already present in {project_id}, offset is {offset}"
+        )
+
+        # format query to be read into GraphiQL endpoint
+        query1 = (
+            "{\n\t"
+            + node_type
+            + '(project_id: "'
+            + project_id
+            + '", first: '
+            + str(n_query)
+            + ", offset:"
+            + str(offset)
+            + "){\n\t\tsubmitter_id\n\t\tid\n\t\tfile_size\n\t\tmd5sum\n\t\tfile_state\n\t\tstate\n\t}\n}"
+        )
+        query2 = {"query": query1, "variables": null}
+
+        # retrieve response
+        response = make_request("post", endpt, secret_name_path, secret_key_name, req_data=query2)
+
+        # check if malformed
+        try:
+            # json.loads(response.text)["data"][node_type]
+            json.loads(response.text)["data"][node_type]
+        except:
+            runner_logger.error(
+                f" Response is malformed: {str(response.text)} for query {str(query2)}, trying again..."  # loads > dumps
+            )
+            response = make_request("post", endpt, secret_name_path, secret_key_name, req_data=query2)
+
+        # check if anymore hits, if not break to speed up process
+
+        if len(json.loads(response.text)["data"][node_type]) == n_query:
+            offset_returns += json.loads(response.text)["data"][node_type]
+        elif len(json.loads(response.text)["data"][node_type]) < n_query:
+            offset_returns += json.loads(response.text)["data"][node_type]
+            runner_logger.info(
+                f" Completed retrieval of previously submitted {node_type} submitter_ids"  # loads > dumps
+            )
+            break
+        else:  # i.e. len(json.loads(response.text)['data'][node_type]) == 0
+            break
+
+
+    return offset_returns

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -175,10 +175,6 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                 f_bucket = row["file_url"].split("/")[2]
                 f_path = "/".join(row["file_url"].split("/")[3:])
                 f_name = os.path.basename(f_path)
-
-                runner_logger.info(f"The bucket is {f_bucket}")
-                runner_logger.info(f"The path is {f_path}")
-                runner_logger.info(f"The file name is {f_name}")
                 
                 if f_name != row["file_name"]:
                     runner_logger.warning(
@@ -223,7 +219,7 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                     commands=[
                         f"{gdc_client_exe_path} upload {row['id']} -t {token_file} -c {chunk_size} -n {n_process}"
                     ],
-                    stream_output=False,
+                    stream_output=True,
                 ).run()
 
                 # check uploads results from streamed output

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -139,6 +139,8 @@ def matching_uuid(manifest_df: pd.DataFrame, entities_in_gdc: pd.DataFrame):
 
     #reorder columns
     manifest_df = manifest_df[['id', 'submitter_id', 'file_name', 'md5sum', 'file_size', 'file_state', 'state', 'file_url', 'status']]
+    already_submitted = already_submitted[['id', 'submitter_id', 'file_name', 'md5sum', 'file_size', 'file_state', 'state', 'file_url', 'status']]
+    not_found_in_gdc = not_found_in_gdc[['id', 'submitter_id', 'file_name', 'md5sum', 'file_size', 'file_state', 'state', 'file_url', 'status']]
     
     return not_found_in_gdc, already_submitted, manifest_df
 

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -80,6 +80,8 @@ def env_setup(bucket, gdc_client_path, project_id, secret_key_name, secret_name_
     # path to gdc-client for uploads
     gdc_client_exe_path = os.path.join(token_dir, "gdc-client")
 
+    runner_logger.info(f">>> ✅ Setting up env complete.")
+
     return token_path, token_dir, gdc_client_exe_path, working_dir, dt
 
 
@@ -281,15 +283,15 @@ def uploader_handler(
             # delete file from VM
             if os.path.exists(f_name):
                 os.remove(f_name)
-                runner_logger.info(f"The file {f_name} has been removed.")
+                runner_logger.info(f"✅ The file {f_name} has been removed.")
             else:
                 runner_logger.warning(
-                    f"The file {f_name} does not exist, cannot remove."
+                    f"❌ The file {f_name} does not exist, cannot remove."
                 )
 
             # check if file deleted from VM
             if os.path.exists(f_name):
-                runner_logger.error(f"The file {f_name} still exists, error removing.")
+                runner_logger.error(f"❌ The file {f_name} still exists, error removing.")
 
     return df
 
@@ -420,7 +422,7 @@ def runner(
         )
 
         runner_logger.info(
-            f">>> Parsing complete, of {len(file_metadata)} starting files,\n\t\t\t {len(matched)} files to upload,\n\t\t\t {len(already_submitted)} files were already submitted and validated,\n\t\t\t {len(not_found_in_gdc)} were not found to be submitted in GDC"
+            f">>> ✅ Parsing complete, of {len(file_metadata)} starting files,\n\t\t {len(matched)} files to upload,\n\t\t {len(already_submitted)} files were already submitted and validated,\n\t\t {len(not_found_in_gdc)} were not found to be submitted in GDC"
         )
 
         if len(matched) > 0:
@@ -517,5 +519,5 @@ def runner(
 
     else:
         runner_logger.error(
-            f"The submitted process_type {process_type} not one of ['upload_files', 'remove_old_working_dirs']"
+            f"The submitted process_type {process_type} not one of ['upload_files', 'remove_old_working_dirs', 'check_status']"
         )

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -68,6 +68,8 @@ def env_setup(bucket, gdc_client_path, project_id, secret_key_name, secret_name_
     # path to token file to provide to gdc-client for uploads
     token_path = os.path.join(token_dir, "token.txt")
 
+    runner_logger.info(f"Token path: {token_path}")
+
     # download the gdc-client
     file_dl(bucket, gdc_client_path)
 
@@ -335,6 +337,10 @@ def runner(
         process_type == "remove_old_working_dirs"
     ):  # remove previous GDC_file_upload working dirs to clear space
 
+        runner_logger.info(
+            f">>> Removing old GDC_file_upload working directories ...."
+        )
+        
         runner_logger.info(
             ShellOperation(
                 commands=[

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -486,13 +486,13 @@ def runner(
             )
 
         # delete token file
-        """if os.path.exists(token_path):
+        if os.path.exists(token_path):
             try:
                 os.remove(token_path)
             except:
                 runner_logger.error(f"Cannot remove file token.txt.")
         else:
-            runner_logger.warning(f"The file token.txt does not exist, cannot remove.")"""
+            runner_logger.warning(f"The file token.txt does not exist, cannot remove.")
 
         # folder upload
         folder_ul(

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -186,7 +186,7 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                     file_dl(f_bucket, f_path)
                     runner_logger.info(f"Downloaded file {f_name}")
             except:
-                runner_logger.error(f"Cannot download file {row['file_name']}")
+                runner_logger.error(f"❌ Cannot download file {row['file_name']}")
                 df.loc[index, 'status'] = "ERROR: File not copied from s3"
                 #subresponses.append([row["id"], row["file_name"], "NOT uploaded", ""])
                 continue  # skip rest of attempt since no file
@@ -194,7 +194,7 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
         # check that file exists
         if not os.path.isfile(row["file_name"]):
             runner_logger.error(
-                f"File {row['file_name']} not copied over or found from URL {row['file_url']}"
+                f"❌ File {row['file_name']} not copied over or found from URL {row['file_url']}"
             )
             #subresponses.append([row["id"], row["file_name"], "NOT uploaded", "File not copied from s3"])
             df.loc[index, 'status'] = f"File {row['file_name']} not copied over or found from URL {row['file_url']}"
@@ -219,12 +219,12 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                     commands=[
                         f"{gdc_client_exe_path} upload {row['id']} -t {token_file} -c {chunk_size} -n {n_process}"
                     ],
-                    stream_output=True,
+                    stream_output=False,
                 ).run()
 
                 # check uploads results from streamed output
                 if f"pload finished for file {row['id']}" in response[-1]:
-                    runner_logger.info(f"Upload finished for file {row['id']}")
+                    runner_logger.info(f"✅ Upload finished for file {row['id']}")
                     #subresponses.append([row["id"], row["file_name"], "uploaded", "success"])
                     df.loc[index, 'status'] = "uploaded"
                 else:
@@ -233,7 +233,7 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                     df.loc[index, 'status'] = "ERROR: NOT uploaded, Failure during upload"
             except Exception as e:
                 runner_logger.error(
-                    f"Upload of file {row['file_name']} (UUID: {row['id']}) failed due to exception: {e}"
+                    f"❌ Upload of file {row['file_name']} (UUID: {row['id']}) failed due to exception: {e}"
                 )
                 #subresponses.append([row["id"], row["file_name"], "NOT uploaded", e])
                 df.loc[index, 'status'] = f"ERROR: {e}, Failure during upload"

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -393,10 +393,10 @@ def runner(
                 upload_part_size_mb,
                 n_processes,
             )
-            responses += subresponses
+            responses.append(subresponses)
 
             #upload intermediate subresponses to S3 in case of crash or cancellation
-            subresponses_df = pd.DataFrame(responses)
+            subresponses_df = pd.concat(responses)
             int_out_fname = f'{working_dir}/{file_name.replace(".tsv", "_intermediate_upload_results.tsv")}'
             # save intermediate response file
             subresponses_df.to_csv(int_out_fname,
@@ -412,7 +412,7 @@ def runner(
 
             )
 
-        responses_df = pd.DataFrame(responses)
+        responses_df = pd.concat(responses)
         
         # save response file
         responses_df.to_csv(

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -322,7 +322,7 @@ def runner(
     Args:
         bucket (str): Bucket name of where the manifest is located in and the response output goes to
         project_id (str): GDC Project ID to submit to (e.g. CCDI-MCI, TARGET-AML)
-        manifest_path (str): File path of the CCDI file manifest in bucket
+        manifest_path (str): File path of the CCDI file manifest in bucket. Manifest must contain cols file_url, file_name, file_size and md5sum.
         gdc_client_path (str): Path to GDC client to download to VM
         node_type (str): Node type to submit to GDC (e.g. submitted_aligned_reads, clinical_supplement, etc.)
         runner (str): Unique runner name and output folder path

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -359,6 +359,17 @@ def runner(
         # check that GDC API status is OK
         runner_logger.info(requests.get("https://api.gdc.cancer.gov/v0/projects").text)
 
+        runner_logger.info(
+            ShellOperation(
+                commands=[
+                    "echo 'check /usr/local/data/'",
+                    "ls -l /usr/local/data/",  # confirm removal of GDC_file_upload working dirs
+                    "echo 'check current working dir'",
+                    "ls -l",  # confirm removal of GDC_file_upload working dirs
+                ]
+            ).run()
+        )
+
     elif process_type == "upload_files":
 
         # setup env

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -114,10 +114,6 @@ def read_input(file_path: str):
 def matching_uuid(manifest_df: pd.DataFrame, entities_in_gdc: pd.DataFrame):
     """Retrieve UUIDs from GDC and match to file rows by md5sum and file_name"""
 
-    print(manifest_df)
-
-    print(already_submitted)
-
     #merge 2 dataframes on md5sum and file_name
     manifest_df = manifest_df.merge(entities_in_gdc, on=["md5sum", "file_name", "file_size"], how="left", suffixes=("", "_gdc"))
     print(manifest_df)
@@ -141,10 +137,6 @@ def matching_uuid(manifest_df: pd.DataFrame, entities_in_gdc: pd.DataFrame):
     print(combined_df.columns)
     
     #drop unnecessary columns
-    
-
-
-
     return None
 
 

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -486,13 +486,13 @@ def runner(
             )
 
         # delete token file
-        if os.path.exists(token_path):
+        """if os.path.exists(token_path):
             try:
                 os.remove(token_path)
             except:
                 runner_logger.error(f"Cannot remove file token.txt.")
         else:
-            runner_logger.warning(f"The file token.txt does not exist, cannot remove.")
+            runner_logger.warning(f"The file token.txt does not exist, cannot remove.")"""
 
         # folder upload
         folder_ul(

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -6,11 +6,8 @@
 #
 ##############
 
-import json
 import requests
 import os
-import sys
-import time
 from prefect_shell import ShellOperation
 import pandas as pd
 from time import sleep

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -68,8 +68,6 @@ def env_setup(bucket, gdc_client_path, project_id, secret_key_name, secret_name_
     # path to token file to provide to gdc-client for uploads
     token_path = os.path.join(token_dir, "token.txt")
 
-    runner_logger.info(f"Token path: {token_path}")
-
     # download the gdc-client
     file_dl(bucket, gdc_client_path)
 

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -219,7 +219,6 @@ def uploader_handler(
             except:
                 runner_logger.error(f"❌ Cannot download file {row['file_name']}")
                 df.loc[index, "status"] = "ERROR: File not copied from s3"
-                # subresponses.append([row["id"], row["file_name"], "NOT uploaded", ""])
                 continue  # skip rest of attempt since no file
 
         # check that file exists
@@ -227,7 +226,6 @@ def uploader_handler(
             runner_logger.error(
                 f"❌ File {row['file_name']} not copied over or found from URL {row['file_url']}"
             )
-            # subresponses.append([row["id"], row["file_name"], "NOT uploaded", "File not copied from s3"])
             df.loc[index, "status"] = (
                 f"File {row['file_name']} not copied over or found from URL {row['file_url']}"
             )
@@ -262,11 +260,9 @@ def uploader_handler(
                 # check uploads results from streamed output
                 if f"pload finished for file {row['id']}" in response[-1]:
                     runner_logger.info(f"✅ Upload finished for file {row['id']}")
-                    # subresponses.append([row["id"], row["file_name"], "uploaded", "success"])
                     df.loc[index, "status"] = "success"
                 else:
                     runner_logger.warning(f"Upload not successful for file {row['id']}")
-                    # subresponses.append([row["id"], row["file_name"], "NOT uploaded", "Failure duing upload"])
                     df.loc[index, "status"] = (
                         "ERROR: NOT uploaded, Failure during upload"
                     )
@@ -274,7 +270,6 @@ def uploader_handler(
                 runner_logger.error(
                     f"❌ Upload of file {row['file_name']} (UUID: {row['id']}) failed due to exception: {e}"
                 )
-                # subresponses.append([row["id"], row["file_name"], "NOT uploaded", e])
                 df.loc[index, "status"] = f"ERROR: {e}, Failure during upload"
 
             # delete file from VM

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -111,12 +111,24 @@ def read_input(file_path: str):
     return file_metadata
 
 @task(name="matching_uuid_task", log_prints=True)
-def matching_uuid(manifest_df, already_submitted):
+def matching_uuid(manifest_df: pd.DataFrame, already_submitted: pd.DataFrame):
     """Retrieve UUIDs from GDC and match to file rows by md5sum and file_name"""
 
     print(manifest_df)
 
     print(already_submitted)
+
+    #merge 2 dataframes on md5sum and file_name
+    manifest_df = manifest_df.merge(already_submitted, on=["md5sum", "file_name"], how="left", suffixes=("", "_already_submitted"))
+    print(manifest_df)
+    print(manifest_df.columns)
+
+    #filter out files in already_submitted with file_state == "validated", status column = "already uploaded, skip"
+
+    #filter out files in manifest_df that do not have a matching md5sum and file_name, status column = "metadata not found, skip"
+
+    #match id in already_submitted to manifest_df by file_name and md5sum, status column left blank
+
 
 
     return None
@@ -332,7 +344,9 @@ def runner(
         # compare md5sum and file_name to already uploaded files
         already_uploaded_df = pd.DataFrame(already_uploaded)
 
-        print(already_uploaded_df)
+        print(already_uploaded_df.to_dict(orient="records"))
+
+        matching_uuid(file_metadata, already_uploaded_df)
 
 
         # number of files to query S3 uploads and then upload consecutively in a flow

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -378,7 +378,7 @@ def runner(
 
         responses = []
 
-        runner_logger.info(f">>> Uploading {len(matched[matched.status == ""])} files in manifest ....")
+        runner_logger.info(f">>> Uploading {len(matched[matched.status == ''])} files in manifest ....")
 
         #exclude for testing for now
         for chunk in range(0, len(matched), chunk_size):

--- a/workflows/gdc_file_upload.py
+++ b/workflows/gdc_file_upload.py
@@ -223,7 +223,7 @@ def uploader_handler(df: pd.DataFrame, gdc_client_exe_path: str, token_file: str
                 ).run()
 
                 # check uploads results from streamed output
-                if f"upload finished for file {row['id']}" in response[-1]:
+                if f"pload finished for file {row['id']}" in response[-1]:
                     runner_logger.info(f"Upload finished for file {row['id']}")
                     #subresponses.append([row["id"], row["file_name"], "uploaded", "success"])
                     df.loc[index, 'status'] = "uploaded"


### PR DESCRIPTION
Updates in PR include: 

- Removing reliance on indexd to find file locations and instead taking input manifest that has this information
- Querying GDC Submission API to find associated UUIDs for files, requiring node_type of files as input to workflow
- Perform UUID matching by matching on file_name, file_size and md5sum
- Filtering out files in manifest that were either already uploaded and validated or not found to have metadata submitted to GDC graph
- Saving filtered out files in manifest to additional output files
- added new workflow option 'check_status' to check GDC API status and add in any test statements if needed
- Add intermediate file output after each chunk is uploaded for handling in case of workflow crash for long runs
-  Adding gdc_utils.py with functions for querying GDC graph etc. and that can be re-used for future GDC workflows that may be needed
- Misc. formatting and logging statement additions