### PR TITLE
CCDIDC-1739  File mover error

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1826,7 +1826,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: main
+          branch: file_mover_error
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_V3.txt
           directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1826,7 +1826,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: file_mover_error
+          branch: main
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_V3.txt
           directory: "{{ clone-step.directory }}"

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -310,13 +310,13 @@ def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger) -> li
 
 @task(
     name="Compare md5sum values",
-    tags=["md5sum-cal-2-tag"],
+    tags=["{concurrency_tag}"],
     retries=3,
     retry_delay_seconds=1,
     log_prints=True,
     cache_policy=NO_CACHE,
 )
-def compare_md5sum_task(first_url: str, second_url: str, s3_client, logger) -> tuple:
+def compare_md5sum_task(first_url: str, second_url: str, s3_client, logger, concurrency_tag) -> tuple:
     """Compares the md5sum of two objects
 
     compare_md5sum_task can return three status for comparison
@@ -357,7 +357,7 @@ def compare_md5sum_task(first_url: str, second_url: str, s3_client, logger) -> t
 
 
 @flow(task_runner=ConcurrentTaskRunner(), name="Compare md5sum Concurrently")
-def compare_md5sum_flow(first_url_list: list[str], second_url_list: list[str]) -> list:
+def compare_md5sum_flow(first_url_list: list[str], second_url_list: list[str], concurrency_tag: str) -> list:
     """Compare md5sum of two list of urls concurrently"""
     s3_client = set_s3_session_client()
     runner_logger = get_run_logger()
@@ -369,7 +369,7 @@ def compare_md5sum_flow(first_url_list: list[str], second_url_list: list[str]) -
         # Submit the task with a delay of 0.25 seconds
         compare_list.append(
             compare_md5sum_task.submit(
-                first_url_list[i], second_url_list[i], s3_client, runner_logger
+                first_url_list[i], second_url_list[i], s3_client, runner_logger, concurrency_tag
             )
         )
 

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -91,8 +91,7 @@ def dest_object_url(url_in_cds: str, dest_bucket_path: str) -> str:
     return dest_url
 
 
-#def copy_large_file(copy_parameter: dict, file_size: int, s3_client, logger) -> None:
-def copy_large_file(copy_parameter: dict, file_size: int, s3_client, runner_logger) -> str:
+def copy_large_file(copy_parameter: dict, file_size: int, s3_client, logger) -> None:
     # collect source bucket, source key, destination bucket, and destination key
     source_bucket, source_key = copy_parameter["CopySource"].split("/", 1)
     copy_source = copy_parameter["CopySource"]
@@ -139,8 +138,7 @@ def copy_large_file(copy_parameter: dict, file_size: int, s3_client, runner_logg
                     part = future.result()
                     parts.append(part)
                 except Exception as e:
-                    #logger.error(f"Error uploading part {part_number}: {e}")
-                    runner_logger.error(f"Error uploading part {part_number}: {e}")
+                    logger.error(f"Error uploading part {part_number}: {e}")
                     raise
 
         # Sort parts by PartNumber before completing the multipart upload
@@ -154,10 +152,10 @@ def copy_large_file(copy_parameter: dict, file_size: int, s3_client, runner_logg
             MultipartUpload={"Parts": parts},
         )
 
-        #logger.info(
-        #    f"Multipart transferred successfully from {copy_source} to {destination_bucket}/{destination_key}"
-        #)
-        runner_logger(
+        logger.info(
+            f"Multipart transferred successfully from {copy_source} to {destination_bucket}/{destination_key}"
+        )
+        print(
             f"Multipart transferred successfully from {copy_source} to {destination_bucket}/{destination_key}"
         )
         transfer_status = "Success"
@@ -166,16 +164,14 @@ def copy_large_file(copy_parameter: dict, file_size: int, s3_client, runner_logg
         s3_client.abort_multipart_upload(
             Bucket=destination_bucket, Key=destination_key, UploadId=upload_id
         )
-        #logger.info(f"Multipart copy Failed to copy file {copy_source}: {e}")
-        runner_logger.info(f"Multipart copy Failed to copy file {copy_source}: {e}")
-        #print(f"Multipart copy Failed to copy file {copy_source}: {e}")
+        logger.info(f"Multipart copy Failed to copy file {copy_source}: {e}")
+        print(f"Multipart copy Failed to copy file {copy_source}: {e}")
         transfer_status = "Fail"
     return transfer_status
 
 
 def copy_file_by_size(
-    #copy_parameter: dict, file_size: int, s3_client, logger, runner_logger
-    copy_parameter: dict, file_size: int, s3_client, runner_logger
+    copy_parameter: dict, file_size: int, s3_client, logger, runner_logger
 ):
     """Copy objects between two locations defined by copy_parameter
 
@@ -188,26 +184,25 @@ def copy_file_by_size(
     copy_source = copy_parameter["CopySource"]
     # test if file_size larger than 5GB, 5*1024*1024*1024
     if file_size > 5368709120:
-        runner_logger.info(
+        # runner_logger.info(
+        #    f"File size {file_size} of {copy_source} larger than 5GB. Start multipart upload process"
+        # )
+        logger.info(
             f"File size {file_size} of {copy_source} larger than 5GB. Start multipart upload process"
         )
-        #logger.info(
-        #    f"File size {file_size} of {copy_source} larger than 5GB. Start multipart upload process"
-        #)
         transfer_status = copy_large_file(
             copy_parameter=copy_parameter,
             file_size=file_size,
             s3_client=s3_client,
-            runner_logger=runner_logger,
-            #logger=logger,
+            logger=logger,
         )
     else:
-        runner_logger.info(
+        # runner_logger.info(
+        #    f"File size {file_size} of {copy_source} less than 5GB. Copy object file using copy_object of s3_client object"
+        # )
+        logger.info(
             f"File size {file_size} of {copy_source} less than 5GB. Copy object file using copy_object of s3_client object"
         )
-        #logger.info(
-        #    f"File size {file_size} of {copy_source} less than 5GB. Copy object file using copy_object of s3_client object"
-        #)
         try:
             s3_client.copy_object(**copy_parameter)
             transfer_status = "Success"
@@ -217,20 +212,20 @@ def copy_file_by_size(
             ex_message = ex.response["Error"]["Message"]
             if ex_code == "NoSuchKey":
                 object_name = ex.response["Error"]["Key"]
-                #logger.error(ex_code + ":" + ex_message + " " + object_name)
+                logger.error(ex_code + ":" + ex_message + " " + object_name)
                 runner_logger.error(ex_code + ":" + ex_message + " " + object_name)
             elif ex_code == "NoSuchBucket":
                 bucket_name = ex.response["Error"]["Code"]["BucketName"]
-                #logger.error(
-                #    ex_code + ":" + ex_message + " Bucket name: " + bucket_name
-                #)
+                logger.error(
+                    ex_code + ":" + ex_message + " Bucket name: " + bucket_name
+                )
                 runner_logger.error(
                     ex_code + ":" + ex_message + " Bucket name: " + bucket_name
                 )
             else:
-                #logger.error(
-                #    "Error info:\n" + json.dumps(ex.response["Error"], indent=4)
-                #)
+                logger.error(
+                    "Error info:\n" + json.dumps(ex.response["Error"], indent=4)
+                )
                 runner_logger.error(
                     "Error info:\n" + json.dumps(ex.response["Error"], indent=4)
                 )
@@ -245,8 +240,7 @@ def copy_file_by_size(
     log_prints=True,
     cache_policy=NO_CACHE,
 )
-#def copy_file_task(copy_parameter: dict, s3_client, logger, runner_logger, concurrency_tag) -> str:
-def copy_file_task(copy_parameter: dict, s3_client, runner_logger, concurrency_tag) -> str:
+def copy_file_task(copy_parameter: dict, s3_client, logger, runner_logger, concurrency_tag) -> str:
     """Copy objects between two locations defined by copy_parameter
 
     It checks if the file has been transferred (Key and object Content length/size) before trasnfer process
@@ -265,9 +259,9 @@ def copy_file_task(copy_parameter: dict, s3_client, runner_logger, concurrency_t
             Bucket=copy_parameter["Bucket"], Key=copy_parameter["Key"]
         )
         if dest_object["ContentLength"] == file_size:
-            #logger.info(
-            #    f"File {copy_source} had already been copied to destination bucket path. Skip"
-            #)
+            logger.info(
+                f"File {copy_source} had already been copied to destination bucket path. Skip"
+            )
             print(
                 f"File {copy_source} had already been copied to destination bucket path. Skip"
             )
@@ -278,7 +272,7 @@ def copy_file_task(copy_parameter: dict, s3_client, runner_logger, concurrency_t
                 copy_parameter=copy_parameter,
                 file_size=file_size,
                 s3_client=s3_client,
-                #logger=logger,
+                logger=logger,
                 runner_logger=runner_logger,
             )
 
@@ -288,15 +282,14 @@ def copy_file_task(copy_parameter: dict, s3_client, runner_logger, concurrency_t
             copy_parameter=copy_parameter,
             file_size=file_size,
             s3_client=s3_client,
-            #logger=logger,
+            logger=logger,
             runner_logger=runner_logger,
         )
     return transfer_status
 
 
 @flow(task_runner=ConcurrentTaskRunner(), name="Copy Files Concurrently")
-#def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger, concurrency_tag) -> list:
-def copy_file_flow(copy_parameter_list: list[dict], runner_logger, concurrency_tag) -> list:
+def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger, concurrency_tag) -> list:
     """Copy of list of file concurrently"""
     s3_client = set_s3_session_client()
     
@@ -305,8 +298,7 @@ def copy_file_flow(copy_parameter_list: list[dict], runner_logger, concurrency_t
     
     for params in copy_parameter_list:
         # Submit the task with a delay of 0.25 seconds
-        #transfer_status_list.append(copy_file_task.submit(params, s3_client, logger, runner_logger, concurrency_tag))
-        transfer_status_list.append(copy_file_task.submit(params, s3_client, runner_logger, concurrency_tag))
+        transfer_status_list.append(copy_file_task.submit(params, s3_client, logger, runner_logger, concurrency_tag))
         
         # Throttle task submission with a 0.25-second delay
         time.sleep(0.25)

--- a/src/file_mover.py
+++ b/src/file_mover.py
@@ -234,13 +234,13 @@ def copy_file_by_size(
 
 @task(
     name="Copy an object file",
-    tags=["file-mover-2-tag"],
+    tags=["{concurrency_tag}"],
     retries=3,
     retry_delay_seconds=1,
     log_prints=True,
     cache_policy=NO_CACHE,
 )
-def copy_file_task(copy_parameter: dict, s3_client, logger, runner_logger) -> str:
+def copy_file_task(copy_parameter: dict, s3_client, logger, runner_logger, concurrency_tag) -> str:
     """Copy objects between two locations defined by copy_parameter
 
     It checks if the file has been transferred (Key and object Content length/size) before trasnfer process
@@ -289,7 +289,7 @@ def copy_file_task(copy_parameter: dict, s3_client, logger, runner_logger) -> st
 
 
 @flow(task_runner=ConcurrentTaskRunner(), name="Copy Files Concurrently")
-def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger) -> list:
+def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger, concurrency_tag) -> list:
     """Copy of list of file concurrently"""
     s3_client = set_s3_session_client()
     
@@ -298,7 +298,7 @@ def copy_file_flow(copy_parameter_list: list[dict], logger, runner_logger) -> li
     
     for params in copy_parameter_list:
         # Submit the task with a delay of 0.25 seconds
-        transfer_status_list.append(copy_file_task.submit(params, s3_client, logger, runner_logger))
+        transfer_status_list.append(copy_file_task.submit(params, s3_client, logger, runner_logger, concurrency_tag))
         
         # Throttle task submission with a 0.25-second delay
         time.sleep(0.25)

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -136,7 +136,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
         item_status = copy_file_task(copy_parameter=copy_parameter, s3_client=s3_client, logger=logger, runner_logger=runner_logger)
         copy_status.append(item_status)"""
     copy_status = copy_file_flow(
-        copy_parameter_list=copy_parameter_list,concurrency_tag="file_mover_delete_copy",logger=logger, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
+        copy_parameter_list=copy_parameter_list,logger=logger, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
     
 
     # compare md5sum

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[-10:]
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
@@ -137,9 +137,8 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
         item_status = copy_file_task(copy_parameter=copy_parameter, s3_client=s3_client, logger=logger, runner_logger=runner_logger)
         copy_status.append(item_status)"""
     copy_status = copy_file_flow(
-        copy_parameter_list=copy_parameter_list,logger=logger, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
+        copy_parameter_list=copy_parameter_list, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
     
-
     # compare md5sum
     runner_logger.info("Start comparing md5sum before and after copy")
     ## KEEP BELOW UNTIL MERGED TO PROD JUST IN CASE

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -4,6 +4,7 @@ import sys
 import pandas as pd
 from typing import TypeVar
 from botocore.errorfactory import ClientError
+from prefect.cache_policies import NO_CACHE
 
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
@@ -67,10 +68,11 @@ def check_if_directory(s3_client, uri_path: str) -> None:
 
 @flow(
         name="If Directory",
-        log_prints=True
+        log_prints=True,
+        cache_policy=NO_CACHE,
 )
-#def identify_obj_dir(uri_list: list, logger) -> list: ##TESTING
-def identify_obj_dir(uri_list: list) -> list:
+def identify_obj_dir(uri_list: list, logger) -> list: ##TESTING
+#def identify_obj_dir(uri_list: list) -> list:
     obj_list = []
     s3_client = set_s3_session_client()
     for uri in uri_list:
@@ -113,13 +115,13 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:10]
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:8] ##TESTING
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
     # identify if the uri in the tsv file dir or obj
-    #uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger) ##TESTING
-    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist())
+    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger) ##TESTING
+    #uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist())
     tsv_df = pd.DataFrame({"original_uri": uri_list})
     logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")
     runner_logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -79,14 +79,14 @@ def identify_obj_dir(uri_list: list, logger) -> list: ##TESTING
         uri_check =  check_if_directory(s3_client=s3_client, uri_path=uri)
         if uri_check == "object":
             obj_list.append(uri)
-            #logger.info(f"uri {uri} is an object")
+            logger.info(f"uri {uri} is an object")
         elif uri_check ==  "directory":
-            #logger.info(f"uri {uri} is a directory")
+            logger.info(f"uri {uri} is a directory")
             uri_item_list = retrieve_objects_from_bucket_path(bucket_folder_path=uri)
             uri_path_list = ["s3://" + i["Bucket"] + "/" + i["Key"] for i in uri_item_list]
             obj_list.extend(uri_path_list)
         else:
-            #logger.error(f"uri {uri} is not valid. Neither obj nor dir")
+            logger.error(f"uri {uri} is not valid. Neither obj nor dir")
             print(f"uri {uri} is not valid. Neither obj nor dir")
 
     return obj_list

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:-15:-10]
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -9,7 +9,7 @@ from prefect.cache_policies import NO_CACHE
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 from src.utils import get_time, file_dl, file_ul, get_date, set_s3_session_client, get_logger
-from src.file_mover import copy_object_parameter, dest_object_url, copy_file_task, parse_file_url, compare_md5sum_flow
+from src.file_mover import copy_object_parameter, dest_object_url, copy_file_flow, parse_file_url, compare_md5sum_flow
 from src.file_remover import objects_deletion, retrieve_objects_from_bucket_path
 
 DataFrame = TypeVar("DataFrame")
@@ -131,10 +131,13 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     runner_logger.info("Start moving files")
     s3_client = set_s3_session_client()
     copy_parameter_list = meta_df["copy_parameter"].tolist()
-    copy_status = []
+    """copy_status = []
     for copy_parameter  in copy_parameter_list:
         item_status = copy_file_task(copy_parameter=copy_parameter, s3_client=s3_client, logger=logger, runner_logger=runner_logger)
-        copy_status.append(item_status)
+        copy_status.append(item_status)"""
+    copy_status = copy_file_flow(
+        copy_parameter_list=copy_parameter_list,concurrency_tag="file_mover_delete_copy",logger=logger, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
+    
 
     # compare md5sum
     runner_logger.info("Start comparing md5sum before and after copy")
@@ -160,16 +163,16 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     first_url_list = meta_df["original_uri"].tolist()
     second_url_list = meta_df["dest_uri"].tolist()
 
-    results = compare_md5sum_flow(
+    md5sum_results = compare_md5sum_flow(
         first_url_list=first_url_list,
         second_url_list=second_url_list,
         concurrency_tag="file_mover_delete_md5sum",
     )
 
     meta_df["copy_status"] = copy_status
-    meta_df["original_md5sum"] = [result[1] for result in results]
-    meta_df["dest_md5sum"] = [result[2] for result in results]
-    meta_df["md5sum_check"] = [result[3] for result in results]
+    meta_df["original_md5sum"] = [result[1] for result in md5sum_results]
+    meta_df["dest_md5sum"] = [result[2] for result in md5sum_results]
+    meta_df["md5sum_check"] = [result[3] for result in md5sum_results]
 
 
     # upload files to bucket

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -144,7 +144,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     for i in range(meta_df.shape[0]):
         original_uri_i = meta_df["original_uri"][i]
         dest_uri_i = meta_df["dest_uri"][i]
-        i_original_md5sum, i_dest_md5sum, comparison_result = compare_md5sum_task(first_url=original_uri_i, second_url=dest_uri_i, s3_client=s3_client,  logger=logger)
+        i_original_url, i_original_md5sum, i_dest_md5sum, comparison_result = compare_md5sum_task(first_url=original_uri_i, second_url=dest_uri_i, s3_client=s3_client, logger=logger)
         first_md5sum.append(i_original_md5sum)
         second_md5sum.append(i_dest_md5sum)
         compare_md5sum_status.append(comparison_result)

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -71,8 +71,7 @@ def check_if_directory(s3_client, uri_path: str) -> None:
         log_prints=True,
         cache_policy=NO_CACHE,
 )
-def identify_obj_dir(uri_list: list, logger) -> list: ##TESTING
-#def identify_obj_dir(uri_list: list) -> list:
+def identify_obj_dir(uri_list: list, logger) -> list:
     obj_list = []
     s3_client = set_s3_session_client()
     for uri in uri_list:
@@ -115,13 +114,12 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:8] ##TESTING
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[9:13] ##TESTING
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
     # identify if the uri in the tsv file dir or obj
-    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger) ##TESTING
-    #uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist())
+    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger)
     tsv_df = pd.DataFrame({"original_uri": uri_list})
     logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")
     runner_logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -66,7 +66,7 @@ def check_if_directory(s3_client, uri_path: str) -> None:
     print(if_dir)
     return if_dir
 
-@flow(
+@task(
         name="If Directory",
         log_prints=True,
         cache_policy=NO_CACHE,

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -165,6 +165,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     results = compare_md5sum_flow(
         first_url_list=first_url_list,
         second_url_list=second_url_list,
+        concurrency_tag="file_mover_delete_md5sum",
     )
 
     meta_df["copy_status"] = copy_status

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -165,8 +165,6 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     results = compare_md5sum_flow(
         first_url_list=first_url_list,
         second_url_list=second_url_list,
-        s3_client=s3_client,
-        logger=runner_logger,
     )
 
     meta_df["copy_status"] = copy_status

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[-10:]
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
@@ -137,8 +137,9 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
         item_status = copy_file_task(copy_parameter=copy_parameter, s3_client=s3_client, logger=logger, runner_logger=runner_logger)
         copy_status.append(item_status)"""
     copy_status = copy_file_flow(
-        copy_parameter_list=copy_parameter_list, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
+        copy_parameter_list=copy_parameter_list,logger=logger, runner_logger=runner_logger, concurrency_tag="file_mover_delete_copy")
     
+
     # compare md5sum
     runner_logger.info("Start comparing md5sum before and after copy")
     ## KEEP BELOW UNTIL MERGED TO PROD JUST IN CASE

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:15]
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:1000]
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:15]
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[16:22] ##TESTING
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
@@ -131,6 +131,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     runner_logger.info("Start moving files")
     s3_client = set_s3_session_client()
     copy_parameter_list = meta_df["copy_parameter"].tolist()
+    ## KEEP BELOW UNTIL MERGED TO PROD JUST IN CASE
     """copy_status = []
     for copy_parameter  in copy_parameter_list:
         item_status = copy_file_task(copy_parameter=copy_parameter, s3_client=s3_client, logger=logger, runner_logger=runner_logger)
@@ -141,6 +142,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
 
     # compare md5sum
     runner_logger.info("Start comparing md5sum before and after copy")
+    ## KEEP BELOW UNTIL MERGED TO PROD JUST IN CASE
     """first_md5sum = []
     second_md5sum = []
     compare_md5sum_status = []

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -114,7 +114,7 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[9:13] ##TESTING
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[16:22] ##TESTING
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 

--- a/workflows/file_mover_delete.py
+++ b/workflows/file_mover_delete.py
@@ -69,21 +69,22 @@ def check_if_directory(s3_client, uri_path: str) -> None:
         name="If Directory",
         log_prints=True
 )
-def identify_obj_dir(uri_list: list, logger) -> list:
+#def identify_obj_dir(uri_list: list, logger) -> list: ##TESTING
+def identify_obj_dir(uri_list: list) -> list:
     obj_list = []
     s3_client = set_s3_session_client()
     for uri in uri_list:
         uri_check =  check_if_directory(s3_client=s3_client, uri_path=uri)
         if uri_check == "object":
             obj_list.append(uri)
-            logger.info(f"uri {uri} is an object")
+            #logger.info(f"uri {uri} is an object")
         elif uri_check ==  "directory":
-            logger.info(f"uri {uri} is a directory")
+            #logger.info(f"uri {uri} is a directory")
             uri_item_list = retrieve_objects_from_bucket_path(bucket_folder_path=uri)
             uri_path_list = ["s3://" + i["Bucket"] + "/" + i["Key"] for i in uri_item_list]
             obj_list.extend(uri_path_list)
         else:
-            logger.error(f"uri {uri} is not valid. Neither obj nor dir")
+            #logger.error(f"uri {uri} is not valid. Neither obj nor dir")
             print(f"uri {uri} is not valid. Neither obj nor dir")
 
     return obj_list
@@ -112,12 +113,13 @@ def file_mover_delete(bucket: str, runner: str, obj_list_tsv_path: str, move_to_
     file_dl(bucket=bucket, filename = obj_list_tsv_path)
     runner_logger.info(f"Downloaded list of s3 uri file: {obj_list_tsv_path}")
     tsv_name = os.path.basename(obj_list_tsv_path)
-    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])
+    tsv_df = pd.read_csv(tsv_name, sep="\t", header=None, names =  ["original_uri"])[:10]
     logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
     runner_logger.info(f"{tsv_df.shape[0]} items were found in file {tsv_name}")
 
     # identify if the uri in the tsv file dir or obj
-    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger)
+    #uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist(), logger=logger) ##TESTING
+    uri_list = identify_obj_dir(uri_list=tsv_df["original_uri"].tolist())
     tsv_df = pd.DataFrame({"original_uri": uri_list})
     logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")
     runner_logger.info(f"A total of {tsv_df.shape[0]} objects will be moved")


### PR DESCRIPTION
Fixing errors in file_mover_delete.py that is causing file-mover-v3 to crash:

- handling extra returned object from one function
- handling of logger object passed to one of the flows
- chunking inputs to flow objects 

Also:

- added efficiency via concurrency in file copying and md5sum checks
- added new specification of concurrency pool to avoid competition for resources  between different, simultaneous runs


