### PR TITLE
CCDIDC 1811 idc validation

### DIFF
--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -1189,7 +1189,7 @@ def validate_bucket_objs_in_manifest(
     
     # exclude open IDC buckets since buckets are too cumbersome to check against
     # and contain data not in our purview 
-    df_file = df_file[~df_file["file_url"].str.contains("idc-open-data")].reset_index(drop=True)
+    df_file = df_file[~df_file["file_url"].str.contains("idc-open-data", regex=False)].reset_index(drop=True)
     
     readable_buckets = [
         bucket for bucket in readable_buckets if bucket not in ["idc-open-data"]


### PR DESCRIPTION
 Exclude open IDC buckets from `validate_bucket_objs_in_manifest()` check since buckets are too cumbersome to check against and contain data not in our purview