### PR TITLE
fixed nonstrict enum list

### DIFF
--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -281,14 +281,14 @@ def validate_terms_value_sets_one_sheet(
     node_name: str,
     checkccdi_object,
     enum_props_dict: dict[str, list[str]],
-    enum_strict_props: list[str],
+    enum_string_props: list[str],
 ) -> str:
     node_df = checkccdi_object.read_sheet_na(sheetname=node_name)
     properties = node_df.columns
     print_str = f"\n\t{node_name}\n\t----------\n\t"
 
     enum_arrays = list(enum_props_dict.keys())
-    enum_string_props = enum_strict_props
+    enum_string_props = enum_string_props
 
     check_list = []
     for property in properties:
@@ -450,7 +450,7 @@ def validate_terms_value_sets_one_sheet(
 def validate_terms_value_sets(
     file_path: str,
     enum_props_dict: dict[str, list[str]],
-    enum_strict_props: list[str],
+    enum_string_props: list[str],
     node_list: list[str],
     output_file: str,
 ) -> None:
@@ -461,13 +461,8 @@ def validate_terms_value_sets(
     )
     
     file_object = CheckCCDI(ccdi_manifest=file_path)
-    validate_str_list = []
-    #for node in node_list:
-    #    print("processing node: " + node)
-    #    validate_str_list.append(validate_terms_value_sets_one_sheet(node, file_object, enum_props_dict, enum_strict_props))
-    #validate_str = "".join(validate_str_list)
     validate_str_future = validate_terms_value_sets_one_sheet.map(
-        node_list, file_object, unmapped(enum_props_dict), unmapped(enum_strict_props)
+        node_list, file_object, unmapped(enum_props_dict), unmapped(enum_string_props)
     )
     validate_str = "".join([i.result() for i in validate_str_future])
     return_str = section_title + validate_str
@@ -2183,7 +2178,11 @@ def validate_acl_authz(file_path: str, output_file: str, node_list: list[str]) -
     log_prints=True,
     flow_run_name="CCDI_ValidationRy_refactor" + f"{get_time()}",
 )
-def ValidationRy_new(file_path: str, template_path: str, enum_props_dict: dict[str, list[str]], enum_strict_props: list[str], model_rel_list: list[dict[str, str]]) -> None:
+def ValidationRy_new(file_path: str, 
+                     template_path: str, 
+                     enum_props_dict: dict[str, list[str]], 
+                     enum_string_props: list[str], 
+                     model_rel_list: list[dict[str, str]]) -> None:
     validation_logger = get_run_logger()
 
     todays_date = get_date()
@@ -2233,12 +2232,7 @@ def ValidationRy_new(file_path: str, template_path: str, enum_props_dict: dict[s
 
     # validate terms and value sets
     validation_logger.info("Checking term and value sets")
-    # create model parser
-    #dcc_model_parser = ModelParser(model_file=model_yaml, props_file=model_props_yaml, handle="ccdi_dcc")
-    #validation_logger.info("Model parser created successfully")
-    #dcc_model = dcc_model_parser.model
-    #validation_logger.info("Model parser model created successfully")
-    validate_terms_value_sets(file_path, enum_props_dict, enum_strict_props, nodes_to_validate, output_file)
+    validate_terms_value_sets(file_path, enum_props_dict, enum_string_props, nodes_to_validate, output_file)
     validation_logger.info("Term and value set validation completed successfully")
 
     # validate integer and numeric vlaues

--- a/workflows/s3-Prefect-Pipeline-dcc.py
+++ b/workflows/s3-Prefect-Pipeline-dcc.py
@@ -92,7 +92,7 @@ def get_enum_string_property_array(model_instance: "MDFReader.model") -> list[st
         for prop in node_instance.props:
             if (
                 isinstance(node_instance.props[prop].values, list)
-                and node_instance.props[prop].is_strict
+                and not node_instance.props[prop].is_strict
             ):
                 enum_string_props.append(prop)
             else:
@@ -281,9 +281,15 @@ def runner_dcc(
             dcc_model = ModelParser(dcc_model_yml, dcc_props_yml, handle="dcc").model
             print("dcc mdf model created")
             enum_props_dict = get_enum_props_dict(dcc_model)
-            enum_strict_props = get_enum_string_property_array(dcc_model)
+            enum_string_props = get_enum_string_property_array(dcc_model)
             model_rel_list = get_rel_from_mdf(dcc_model)
-            validation_out_file = ValidationRy_new(catcherr_out_file, input_template, enum_props_dict, enum_strict_props, model_rel_list)
+            validation_out_file = ValidationRy_new(
+                file_path=catcherr_out_file,
+                template_path=input_template,
+                enum_props_dict=enum_props_dict,
+                enum_string_props=enum_string_props,
+                model_rel_list=model_rel_list
+            )
         except Exception as e:
             validation_out_file = None
             raise e # stop flow at here if Validation fails

--- a/workflows/s3-Prefect-Pipeline-dcc.py
+++ b/workflows/s3-Prefect-Pipeline-dcc.py
@@ -78,13 +78,13 @@ def get_enum_props_dict(model_instance: "MDFReader.model") -> dict[str, list[str
     return enum_props_dict
 
 def get_enum_string_property_array(model_instance: "MDFReader.model") -> list[str]:
-    """Generate a list of property names, which is stricted to its Permissible Values (PV) list
+    """Generate a list of enum property names, which is non-stricted to its Permissible Values (PV) list
 
     Args:
         model_instance (MDFReader.model): MDFReader.model instance
 
     Returns:
-        list[str]: a list of property names, which are stricted to its own PV list
+        list[str]: a list of property names, which are non-stricted to its own PV list
     """
     enum_string_props = []
     for node in model_instance.nodes:


### PR DESCRIPTION
Added patch

- Strict enum properties were wrongly recognized as nonstrict enum properties, and passed along as nonstrict enum properties. Now nonstrict enum properties are recognized properly.