### PR TITLE
CCDIDC-2431 Pull single manifest from neo4j

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1249,9 +1249,8 @@ deployments:
     # flow-specific parameters
     parameters:
       bucket: "ccdi-validation"
-      runner: ""
       study_id: "phs002790"
-      ccdi_template_tag: "3.1.0"
+      dcc_template_tag: "3.1.0"
     
 
     # pull action to overwrite from file pull action
@@ -1862,5 +1861,35 @@ deployments:
     # infra-specific fields
     work_pool:
       name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
+      work_queue_name: null
+      job_variables: {}
+
+  - name: pull_n_join_ccdi_manifest_single_study
+    version: null
+    tags: ["Production", "V3", "CCDI", "Centralized Worker"]
+    description: null
+    entrypoint: workflows/pull_n_join_manifest_single_study.py:pull_neo4j_join_manifest_single_study
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+      study_id: "phs002790"
+      ccdi_template_tag: "3.1.0"
+    
+    # pull action to overwrite from file pull action
+    pull:
+    - prefect.deployments.steps.git_clone:
+        id: clone-step
+        repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+        branch: main
+    - prefect.deployments.steps.pip_install_requirements:
+        requirements_file: requirements_python3.13_prefect3.txt
+        directory: "{{ clone-step.directory }}"
+        stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-dcc-16gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}

--- a/src/join_tsv_to_manifest.py
+++ b/src/join_tsv_to_manifest.py
@@ -108,8 +108,8 @@ def unpack_folder_list(folder_path_list: list[str]):
     return unpacked_folder_list
 
 
-@task(name="Join tsv to Manifest", log_prints=True)
-def join_tsv_to_manifest_single_study(file_list: list[str], manifest_path: str) -> str:
+@task(name="Join tsv to CCDI Manifest", log_prints=True)
+def join_tsv_to_ccdi_manifest_single_study(file_list: list[str], manifest_path: str) -> str:
     logger = get_run_logger()
     # Remove the step of checking if only one phs is found under id column
     # Because the
@@ -192,14 +192,14 @@ def join_tsv_to_manifest_single_study(file_list: list[str], manifest_path: str) 
     return output_file_name
 
 
-@flow(name="Join tsv to Manifest Concurrently")
-def multi_studies_tsv_join(folder_path_list: list, manifest_path: str) -> list[str]:
+@flow(name="Join tsv to CCDI Manifest Concurrently")
+def multi_studies_tsv_join_ccdi(folder_path_list: list, manifest_path: str) -> list[str]:
     logger = get_run_logger()
     logger.info(f"Subfolder counts: {len(folder_path_list)}")
 
     unpacked_folder_list = unpack_folder_list(folder_path_list=folder_path_list)
     logger.info("Start creating manifest files concurrently")
-    manifest_outputs = join_tsv_to_manifest_single_study.map(
+    manifest_outputs = join_tsv_to_ccdi_manifest_single_study.map(
         unpacked_folder_list, manifest_path
     )
     return [i.result() for i in manifest_outputs]

--- a/workflows/db_tsv_to_manifest.py
+++ b/workflows/db_tsv_to_manifest.py
@@ -4,11 +4,15 @@ import os
 
 parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
-from src.utils import CCDI_DCC_Tags, get_time, folder_dl, file_ul
+from src.utils import CCDI_DCC_Tags, CCDI_Tags, get_time, folder_dl, file_ul
 from src.join_tsv_to_manifest_dcc import (
     join_tsv_to_manifest_single_study,
     multi_studies_tsv_join,
     check_subfolder,
+)
+from src.join_tsv_to_manifest import (
+    join_tsv_to_ccdi_manifest_single_study,
+    multi_studies_tsv_join_ccdi,
 )
 
 
@@ -75,6 +79,86 @@ def join_tsv_to_manifest(
             if os.path.isdir(os.path.join(tsv_folder_path, i))
         ]
         manifest_output_list = multi_studies_tsv_join(
+            folder_path_list=subfolders_list, manifest_path=ccdi_manifest
+        )
+        logger.info(f"List of CCDI manifests generated: {*manifest_output_list,}")
+    else:
+        pass
+
+    # upload outputs to the bucket
+    output_folder = os.path.join(runner, "join_tsv_to_manifest_" + current_time)
+    logger.info(f"Output(s) will be uploaded to bucket {bucket} folder {output_folder}")
+    for k in manifest_output_list:
+        logger.info(f"Uploading {k}")
+        file_ul(bucket=bucket, output_folder=output_folder, sub_folder="", newfile=k)
+    logger.info("workflow finished!")
+
+    return None
+
+
+@flow(
+    name="Join TSV files to CCDI manifest",
+    log_prints=True,
+    flow_run_name="join-tsv-to-ccdi-manifest-{runner}-" + f"{get_time()}",
+)
+def join_tsv_to_ccdi_manifest(
+    bucket: str, runner: str, tsv_folder_path: str, ccdi_template_tag: str
+) -> None:
+    """Pipeline that combines a folder of tsv files into a single CCDI manifest
+
+    Args:
+        bucket (str): Bucket name of where tsv files located in and output goes to
+        runner (str): Unique runner name
+        tsv_folder_path (str): Folder path of tsv files in the bucket
+        ccdi_template_tag (str): Tag name of the CCDI template to use for the manifest generation.
+
+    Raises:
+        ValueError: Value Error raised if pipeline fails to proceed
+    """
+    logger = get_run_logger()
+    current_time = get_time()
+
+    # download the ccdi manifest of a given tag
+    logger.info("")
+    ccdi_manifest = CCDI_Tags().download_tag_manifest(
+        tag=ccdi_template_tag, logger=logger
+    )
+    if ccdi_manifest is None:
+        raise ValueError(
+            "Failed to download CCDI manifest from github repo. No further execution."
+        )
+    else:
+        pass
+
+    # download the folder
+    logger.info("Downloading folder from bucket")
+    folder_dl(bucket=bucket, remote_folder=tsv_folder_path)
+
+    # decide if the downloaded folder has multiple subfolder structure
+    # subfolder structure applies to
+    folder_check = check_subfolder(folder_path=tsv_folder_path, logger=logger)
+
+    if folder_check == "single":
+        logger.info(f"Folder {tsv_folder_path} contains tsv files only")
+        file_list = [
+            os.path.join(tsv_folder_path, i)
+            for i in os.listdir(tsv_folder_path)
+            if i.endswith("tsv")
+        ]
+        manifest_output = join_tsv_to_ccdi_manifest_single_study(
+            file_list=file_list, manifest_path=ccdi_manifest
+        )
+        manifest_output_list = []
+        manifest_output_list.append(manifest_output)
+        logger.info(f"CCDI manifest {manifest_output} generated ")
+    elif folder_check == "multiple":
+        logger.info(f"Folder {tsv_folder_path} contains subfolders of multiple studies")
+        subfolders_list = [
+            os.path.join(tsv_folder_path, i)
+            for i in os.listdir(tsv_folder_path)
+            if os.path.isdir(os.path.join(tsv_folder_path, i))
+        ]
+        manifest_output_list = multi_studies_tsv_join_ccdi(
             folder_path_list=subfolders_list, manifest_path=ccdi_manifest
         )
         logger.info(f"List of CCDI manifests generated: {*manifest_output_list,}")

--- a/workflows/pull_n_join_manifest_single_study.py
+++ b/workflows/pull_n_join_manifest_single_study.py
@@ -3,8 +3,9 @@ from prefect import flow, task, get_run_logger
 import os
 import sys
 
+from workflows.pull_neo4j_data import pull_neo4j_data
 from workflows.pull_db_data import pull_db_data
-from workflows.db_tsv_to_manifest import join_tsv_to_manifest
+from workflows.db_tsv_to_manifest import join_tsv_to_manifest, join_tsv_to_ccdi_manifest
 
 
 @flow(
@@ -64,6 +65,68 @@ def pull_n_join_manifest_single_study(
         runner=runner,
         tsv_folder_path=op_folder_path,
         dcc_template_tag=dcc_template_tag,
+    )
+
+    return None
+
+
+@flow(
+    name="Pull neo4j data and join to manifest for single study",
+    log_prints=True,
+    flow_run_name="pull-neo4j-join-tsvs-{runner}-" + f"{get_time()}",
+)
+def pull_neo4j_join_manifest_single_study(
+    bucket: str,
+    runner: str,
+    database_account_id: str,
+    database_secret_path: str,
+    database_secret_key_ip: str,
+    database_secret_key_username: str,
+    database_secret_key_password: str,
+    study_id: str,
+    dcc_template_tag: str,
+):
+    """Pipeline that pulls ingested study from a Neo4j database for study phs ID provided.
+
+    Args:
+        bucket (str): The S3 bucket to pull data from.
+        runner (str): The runner to use for the workflow.
+        database_account_id (str): AWS account ID for accessing secrets
+        database_secret_path (str): Path to the secret in AWS Secrets Manager
+        database_secret_key_ip (str): Key name for the URI in the secret
+        database_secret_key_username (str): Key name for the username in the secret
+        database_secret_key_password (str): Key name for the password in the secret
+        study_id (str): The study ID to pull data for.
+        dcc_template_tag (str): Tag name of the DCC template
+    """
+
+    logger = get_run_logger()
+    logger.info(
+        f"Pulling joined Neo4j data for study {study_id} from bucket {bucket} using runner {runner}"
+    )
+
+    op_folder = pull_neo4j_data(
+        bucket=bucket,
+        runner=runner,
+        database_account_id=database_account_id,
+        database_secret_path=database_secret_path,
+        database_secret_key_ip=database_secret_key_ip,
+        database_secret_key_username=database_secret_key_username,
+        database_secret_key_password=database_secret_key_password,
+        study_id_list=[study_id],
+    )
+
+    op_folder_path = f"{op_folder}/{study_id}".replace(
+        "s3://" + bucket + "/", ""
+    ).replace("/./", "/")
+
+    logger.info(f"Pulled data stored at {op_folder_path}")
+
+    join_tsv_to_ccdi_manifest(
+        bucket=bucket,
+        runner=runner,
+        tsv_folder_path=op_folder_path,
+        ccdi_template_tag=dcc_template_tag,
     )
 
     return None

--- a/workflows/pull_n_join_manifest_single_study.py
+++ b/workflows/pull_n_join_manifest_single_study.py
@@ -84,7 +84,7 @@ def pull_neo4j_join_manifest_single_study(
     database_secret_key_username: str,
     database_secret_key_password: str,
     study_id: str,
-    dcc_template_tag: str,
+    ccdi_template_tag: str,
 ):
     """Pipeline that pulls ingested study from a Neo4j database for study phs ID provided.
 
@@ -97,7 +97,7 @@ def pull_neo4j_join_manifest_single_study(
         database_secret_key_username (str): Key name for the username in the secret
         database_secret_key_password (str): Key name for the password in the secret
         study_id (str): The study ID to pull data for.
-        dcc_template_tag (str): Tag name of the DCC template
+        ccdi_template_tag (str): Tag name of the DCC template
     """
 
     logger = get_run_logger()
@@ -126,7 +126,7 @@ def pull_neo4j_join_manifest_single_study(
         bucket=bucket,
         runner=runner,
         tsv_folder_path=op_folder_path,
-        ccdi_template_tag=dcc_template_tag,
+        ccdi_template_tag=ccdi_template_tag,
     )
 
     return None


### PR DESCRIPTION
Added patch

- Created workflow to pull data from Neo4j db of a single study to form manifest
    - Use centralized worker for deployment