### PR TITLE
fix: Data Loading IDs as strings Liftover Helper

### DIFF
--- a/workflows/gc_liftover_helper.py
+++ b/workflows/gc_liftover_helper.py
@@ -14,6 +14,20 @@ def load_tsvs_from_folder(folder_path):
         'sample.sample_age_at_collection', 
         'consent_group.consent_group_number'
     }
+
+    str_cols = {
+    'study.phs_accession',
+    'study.study_acronym',
+    'investigator.primary_investigator_email',
+    'participant.participant_id',
+    'sample.participant.study_participant_id',
+    'diagnosis.participant.study_participant_id',
+    'diagnosis.diagnosis_id',
+    'treatment.participant.study_participant_id',
+    'treatment.therapeutic_agents',
+    'genomic_info.file.file_id',
+    'genomic_info.library_id',
+}
     
     sheet_dfs = {}
     for file in os.listdir(folder_path):
@@ -26,6 +40,8 @@ def load_tsvs_from_folder(folder_path):
             for col in df.columns:
                 if f"{file_name}.{col}" in int_cols:
                     df[col] = pd.to_numeric(df[col], errors='coerce').astype('Int64')
+                elif f"{file_name}.{col}" in str_cols:
+                    df[col] = df[col].astype(str).str.strip()
             
             sheet_dfs[file_name] = df
     return sheet_dfs

--- a/workflows/gc_liftover_helper.py
+++ b/workflows/gc_liftover_helper.py
@@ -14,20 +14,6 @@ def load_tsvs_from_folder(folder_path):
         'sample.sample_age_at_collection', 
         'consent_group.consent_group_number'
     }
-
-    str_cols = {
-    'study.phs_accession',
-    'study.study_acronym',
-    'investigator.primary_investigator_email',
-    'participant.participant_id',
-    'sample.participant.study_participant_id',
-    'diagnosis.participant.study_participant_id',
-    'diagnosis.diagnosis_id',
-    'treatment.participant.study_participant_id',
-    'treatment.therapeutic_agents',
-    'genomic_info.file.file_id',
-    'genomic_info.library_id',
-}
     
     sheet_dfs = {}
     for file in os.listdir(folder_path):
@@ -40,7 +26,7 @@ def load_tsvs_from_folder(folder_path):
             for col in df.columns:
                 if f"{file_name}.{col}" in int_cols:
                     df[col] = pd.to_numeric(df[col], errors='coerce').astype('Int64')
-                elif f"{file_name}.{col}" in str_cols:
+                elif f"{file_name}.{col}" not in int_cols:
                     df[col] = df[col].astype(str).str.strip()
             
             sheet_dfs[file_name] = df


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Fix dtype inference issues in TSV loader</h2>
<h3>Problem</h3>
<p><code>pd.read_csv()</code> was inferring <code>float64</code> for ID columns that contained only numeric values (e.g. <code>participant_id = 1, 2, 3</code>). This caused <code>UFuncTypeError</code> when downstream code attempted string concatenation to build IDs like <code>study_participant_id</code>.</p>
<h3>Changes</h3>
<ul>
<li>All columns are cast to str by default on load, with int_cols as the only exceptions
<li>Removed <code>.convert_dtypes()</code> from the TSV loader, which was causing aggressive type inference (numeric-looking IDs → <code>Int64</code>, all-null columns → <code>Int64</code> instead of string)</li>
<li>Added explicit <code>int_cols</code> set for true numeric columns (<code>bases</code>, <code>number_of_reads</code>, <code>age_at_diagnosis</code>, etc.) — cast to nullable <code>Int64</code> via <code>pd.to_numeric(errors='coerce')</code> to preserve NaNs without float promotion</li>
</ul>
<h3>Affected columns</h3>

Cast | Columns
-- | --
Int64 | bases, number_of_reads, age_at_diagnosis, sample_age_at_collection, consent_group_number
str | participant_id, phs_accession, study_acronym, diagnosis_id, therapeutic_agents, file.file_id, library_id, primary_investigator_email, participant.study_participant_id (sample, diagnosis, treatment)

</body></html><!--EndFragment-->
</body>
</html>