### PR TITLE
Ccdidc 2474 refactor mmm

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2103,7 +2103,7 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       runner: "your_uniq_id"
-      old_model_repository: "ccdi-model"
+      old_model_repository: "ccdi-dcc-model"
       new_model_repository: "cds-model"
       old_model_version: "1.0.0"
       new_model_version: "11.0.4-GC_Release"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -70,11 +70,6 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-      #runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
 
     # pull action to overwrite from file pull action
     pull:
@@ -104,11 +99,6 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-      #runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
 
     # pull action to overwrite from file pull action
     pull:
@@ -138,11 +128,6 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-      #runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
 
     # pull action to overwrite from file pull action
     pull:
@@ -172,11 +157,6 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-      #runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
 
     # pull action to overwrite from file pull action
     pull:
@@ -206,11 +186,6 @@ deployments:
     parameters:
       bucket: "ccdi-validation"
       file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-      #runner: "your_uniq_id"
-      #optional parmaeters below, uncomment if needed
-      #output_folder: "output_folder_name"
-      #template_path: "inputs/CCDI_Submission_Template_v1.7.1.xlsx"
-      #sra_template_path: "inputs/phsXXXXXX.xlsx"
 
     # pull action to overwrite from file pull action
     pull:
@@ -346,102 +321,7 @@ deployments:
       work_queue_name: null
       job_variables: {}
 
-  # - name: validate-neo4j-data-32gb-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: workflows/validate_neo4j_data.py:validate_neo4j_data
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_V3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
-
-  #   # infra-specific fields
-  #   work_pool:
-  #     name: ccdi-curation-60gb-prefect-3.2.14-python3.9
-  #     work_queue_name: null
-  #     job_variables: {}
-
-  # - name: ccdi-guid-checker-32gb-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: workflows/guid_checker.py:guid_checker_runner
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-  #     file_path: "inputs/CCDI_Submission_Template_v1.7.2_10ExampleR20231228.xlsx"
-  #     runner: "your_uniq_id"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_python3.13_prefect3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
-
-  #   # infra-specific fields
-  #   work_pool:
-  #     name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
-  #     work_queue_name: null
-  #     job_variables: {}
-
   # base metadata
-  - name: model-mapping-maker-8gb-v3
-    version: null
-    tags: ["Production","V3"]
-    description: null
-    entrypoint: workflows/model_mapping_maker.py:runner
-    schedule: null
-
-    # flow-specific parameters
-    parameters:
-      bucket: "ccdi-validation"
-      runner: "your_uniq_id"
-      old_model_repository: "ccdi-model"
-      new_model_repository: "ccdi-model"
-      old_model_file_location: "model-desc/ccdi-model.yml"
-      new_model_file_location: "model-desc/ccdi-model.yml"
-      old_model_version: ""
-      new_model_version: ""
-      base_mode:  False 
-      nodes_mapping_file: "path_to/nodes_file/in/s3_bucket"
-      relationship_mapping_file: "path_to/nodes_file/in/s3_bucket"
-
-    # pull action to overwrite from file pull action
-    pull:
-      - prefect.deployments.steps.git_clone:
-          id: clone-step
-          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: main
-      - prefect.deployments.steps.pip_install_requirements:
-          requirements_file: requirements_python3.13_prefect3.txt
-          directory: "{{ clone-step.directory }}"
-          stream_output: False
-
-    # infra-specific fields
-    work_pool:
-      name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
-      work_queue_name: null
-      job_variables: {} 
 
   - name: ccdi-template-liftover-v3
     version: null
@@ -808,78 +688,6 @@ deployments:
       name: ccdi-dcc-60gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}
-      
-  # - name: neo4j-stats-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: workflows/neo4j_stats.py:pull_neo4j_stats
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_V3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
-
-  #   # infra-specific fields
-  #   work_pool:
-  #     name: ccdi-curation-60gb-prefect-3.2.14-python3.9
-  #     work_queue_name: null
-  #     job_variables: {}  
-
-  # - name: join-tsv-to-manifest_OLD-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: workflows/db_tsv_to_manifest.py:join_tsv_to_manifest
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_python3.13_prefect3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
-
-  # - name: guid-meta-check-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: src/sandbox_indexd_guid_validation.py:guid_validation_between_sandbox_indexd
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_python3.13_prefect3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
 
   - name: DB-props-uniq-report-v3
     version: null
@@ -936,38 +744,6 @@ deployments:
       name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}
-
-  #- name: ccdi-gdc-transformation-16gb-v3
-  #  version: null
-  #  tags: ["Production","V3"]
-  #  description: null
-  #  entrypoint: workflows/ccdi_to_gdc.py:ccdi_to_gdc_run
-  #  schedule: null
-
-  #  # flow-specific parameters
-  #  parameters:
-  #    bucket: "ccdi-validation"
-  #    runner: "runner_id"
-  #    file_path: "inputs/CCDI_Submission_Template_v1.9.1_20Exampler.xlsx"
-  #    ccdi_gdc_translation_file: ""
-  #    platform_preservation_file: ""
-
-  #  # pull action to overwrite from file pull action
-  #  pull:
-  #    - prefect.deployments.steps.git_clone:
-  #        id: clone-step
-  #        repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #        branch: main
-  #    - prefect.deployments.steps.pip_install_requirements:
-  #        requirements_file: requirements_python3.13_prefect3.txt
-  #        directory: "{{ clone-step.directory }}"
-  #        stream_output: False
-
-  # # infra-specific fields
-  #  work_pool:
-  #    name: ccdi-dcc-16gb-prefect-3.4.19-python3.13
-  #    work_queue_name: null
-  #    job_variables: {}
 
   # base metadata
   - name: ccdi-gdc-import-v3
@@ -1044,37 +820,6 @@ deployments:
       name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}
-
-  # - name: ccdi-neo4j-db_diff-v3
-  #   version: null
-  #   tags: ["Production","V3"]
-  #   description: null
-  #   entrypoint: workflows/neo4j_db_diff.py:diff_sandbox_dev_neo4j
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-  #     runner: "your_uniq_id"
-  #     database_1: "Curation"
-  #     database_2: "Dev"
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #     - prefect.deployments.steps.git_clone:
-  #         id: clone-step
-  #         repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #         branch: main
-  #     - prefect.deployments.steps.pip_install_requirements:
-  #         requirements_file: requirements_python3.13_prefect3.txt
-  #         directory: "{{ clone-step.directory }}"
-  #         stream_output: False
-
-  #   # infra-specific fields
-  #   work_pool:
-  #     name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
-  #     work_queue_name: null
-  #     job_variables: {}
 
   - name: compare-dataframes-v3
     version: null
@@ -1297,42 +1042,6 @@ deployments:
       name: ccdi-dcc-16gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}
-
-  # - name: memgraph_transfer
-  #   version: null
-  #   tags: ["Production", "V3"]
-  #   description: null
-  #   entrypoint: workflows/memgraph_transfer.py:memgraph_export_import_flow
-  #   schedule: null
-
-  #   # flow-specific parameters
-  #   parameters:
-  #     bucket: "ccdi-validation"
-  #     runner: ""
-  #     file_path: "directory/path/to/file.cypherl"
-  #     uri_parameter: "uri_memgraph"
-  #     username_parameter: "username_memgraph"
-  #     password_parameter: "password_memgraph"
-  #     mode: "export"
-  #     chunk_size: 1000
-  #     wipe_db: false
-
-  #   # pull action to overwrite from file pull action
-  #   pull:
-  #   - prefect.deployments.steps.git_clone:
-  #       id: clone-step
-  #       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-  #       branch: main
-  #   - prefect.deployments.steps.pip_install_requirements:
-  #       requirements_file: requirements_python3.13_prefect3.txt
-  #       directory: "{{ clone-step.directory }}"
-  #       stream_output: False
-
-  #   # infra-specific fields
-  #   work_pool:
-  #     name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
-  #     work_queue_name: null
-  #     job_variables: {}
 
   - name: hello-world-v3
     version: null
@@ -2092,9 +1801,9 @@ deployments:
       work_queue_name: null
       job_variables: {}
 
-  - name: TEST-model-mapping-maker-8gb-v3
+  - name: model-mapping-maker-8gb-v3
     version: null
-    tags: ["TEST","V3"]
+    tags: ["Production","MDF","MEVAL","Centralized Worker","V3"]
     description: null
     entrypoint: workflows/model_mapping_maker.py:runner
     schedule: null
@@ -2115,7 +1824,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: CCDIDC-2474_Refactor_MMM
+          branch: main
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_python3.13_prefect3.txt
           directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2104,12 +2104,10 @@ deployments:
       bucket: "ccdi-validation"
       runner: "your_uniq_id"
       old_model_repository: "ccdi-model"
-      new_model_repository: "ccdi-model"
-      old_model_file_location: "model-desc/ccdi-model.yml"
-      new_model_file_location: "model-desc/ccdi-model.yml"
-      old_model_version: ""
-      new_model_version: ""
-      base_mode:  False 
+      new_model_repository: "cds-model"
+      old_model_version: "1.0.0"
+      new_model_version: "11.0.4-GC_Release"
+      base_mode: True 
       mapping_file: "path_to/mapping_file/in/s3_bucket.tsv"
 
     # pull action to overwrite from file pull action

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2117,7 +2117,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: main
+          branch: CCDIDC-2474_Refactor_MMM
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_python3.13_prefect3.txt
           directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -2091,3 +2091,40 @@ deployments:
       name: ccdi-dcc-16gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {}
+
+  - name: TEST-model-mapping-maker-8gb-v3
+    version: null
+    tags: ["TEST","V3"]
+    description: null
+    entrypoint: workflows/model_mapping_maker.py:runner
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+      runner: "your_uniq_id"
+      old_model_repository: "ccdi-model"
+      new_model_repository: "ccdi-model"
+      old_model_file_location: "model-desc/ccdi-model.yml"
+      new_model_file_location: "model-desc/ccdi-model.yml"
+      old_model_version: ""
+      new_model_version: ""
+      base_mode:  False 
+      mapping_file: "path_to/mapping_file/in/s3_bucket.tsv"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.deployments.steps.git_clone:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: main
+      - prefect.deployments.steps.pip_install_requirements:
+          requirements_file: requirements_python3.13_prefect3.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
+      work_queue_name: null
+      job_variables: {} 

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -10,6 +10,7 @@ hyperframe==6.1.0
 importlib_metadata==8.7.1
 jmespath==1.1.0
 Markdown==3.10.2
+ctos-meval==1.1.0
 neo4j==6.1.0
 numpy==2.4.4
 openpyxl==3.1.5

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -12,6 +12,7 @@ jmespath==1.1.0
 Markdown==3.10.2
 ctos-meval==1.1.0
 neo4j==6.2.0
+neo4j-viz==1.0.0
 numpy==2.4.4
 openpyxl==3.1.5
 pandas==2.2.3

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -11,7 +11,7 @@ importlib_metadata==8.7.1
 jmespath==1.1.0
 Markdown==3.10.2
 ctos-meval==1.1.0
-neo4j==6.1.0
+neo4j==6.2.0
 numpy==2.4.4
 openpyxl==3.1.5
 pandas==2.2.3

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -10,7 +10,7 @@ hyperframe==6.1.0
 importlib_metadata==8.7.1
 jmespath==1.1.0
 Markdown==3.10.2
-ctos-meval==1.1.0
+ctos-meval==1.1.1
 neo4j==6.2.0
 neo4j-viz==1.0.0
 numpy==2.4.4

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -1,4 +1,4 @@
-bento-mdf==0.13.0
+bento-mdf==0.13.1
 boto3==1.42.70
 botocore==1.42.70
 deepdiff==9.0.0

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -15,7 +15,7 @@ neo4j==6.2.0
 neo4j-viz==1.0.0
 numpy==2.4.4
 openpyxl==3.1.5
-pandas==2.3.3
+pandas==2.2.3
 pip-autoremove==0.10.0
 prefect-aws==0.5.9
 prefect-docker==0.6.2

--- a/requirements_python3.13_prefect3.txt
+++ b/requirements_python3.13_prefect3.txt
@@ -15,7 +15,7 @@ neo4j==6.2.0
 neo4j-viz==1.0.0
 numpy==2.4.4
 openpyxl==3.1.5
-pandas==2.2.3
+pandas==2.3.3
 pip-autoremove==0.10.0
 prefect-aws==0.5.9
 prefect-docker==0.6.2

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -273,6 +273,7 @@ def runner(
 
         mapping_df = build_mapping(df_from, df_to)
 
+    if not base_mode:
         user_input_location(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property",   "lift_to_version",   base_mode, "fromto")
         user_input_location(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property", "lift_from_version", base_mode, "tofrom")
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -56,8 +56,12 @@ def parse_model(model_parsed, version):
 
     for node in model_parsed.get_node_list():
         for parent in model_parsed.get_parent_nodes(node):
-            key_prop = model_parsed.get_node_key_prop(parent)
-            rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
+            # handle top level nodes without parents - skip as they won't have a parent property to map to
+            if not parent:
+                continue
+            else:
+                key_prop = model_parsed.get_node_key_prop(parent)
+                rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -37,6 +37,7 @@ def pull_model_data_files(model, version, file_type, output_file):
 
 # ── extraction ────────────────────────────────────────────────────────────────
 
+@task
 def parse_model(model_parsed, version):
     rows = []
     print(f"Starting to parse model for version: {version}")
@@ -48,7 +49,6 @@ def parse_model(model_parsed, version):
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in node_list:
-        print(f"Things are getting pushed, right?")
         print(f"Parsing relationships for node: {node}")
         parent_nodes = model_parsed.get_parent_nodes(node)
         print(f"Parent nodes of node: {node} are: {parent_nodes}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -59,12 +59,12 @@ def parse_model(model_parsed, version):
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in model_parsed.get_node_list():
-        logger.info(f"Parsing relationships for node: {node}")
+        #logger.info(f"Parsing relationships for node: {node}")
         for parent in model_parsed.get_parent_nodes(node):
             logger.info(f"Parsing parent node: {parent} of node: {node}")
             # handle top level nodes without parents - skip as they won't have a parent property to map to
             if not parent:
-                continue
+                logger.info(f"Node: {node} has no parent nodes, skipping relationship parsing for this node.")
             else:
                 key_prop = model_parsed.get_node_key_prop(parent)
                 rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -9,18 +9,22 @@ from meval.parser import ModelParser
 import requests
 
 
-
 class InputValues(RunInput):
     node: str
     property: str
 
 
 COLUMNS = [
-    "lift_from_node", "lift_from_property", "lift_from_version",
-    "lift_to_node",   "lift_to_property",   "lift_to_version",
+    "lift_from_node",
+    "lift_from_property",
+    "lift_from_version",
+    "lift_to_node",
+    "lift_to_property",
+    "lift_to_version",
 ]
 
 # ── helpers ───────────────────────────────────────────────────────────────────
+
 
 def pull_model_data_files(model, version, file_type, output_file):
     if file_type == "model":
@@ -30,45 +34,59 @@ def pull_model_data_files(model, version, file_type, output_file):
     response = requests.get(url)
     response.raise_for_status()
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         f.write(response.text)
 
     return output_file
 
+
 # ── extraction ────────────────────────────────────────────────────────────────
+
 
 @task
 def parse_model(model_parsed, version):
+    logger = get_run_logger()
     rows = []
-    print(f"Starting to parse model for version: {version}")
+    logger.info(f"Starting to parse model for version: {version}")
     node_list = model_parsed.get_node_list()
 
     for node in node_list:
-        print(f"Parsing node: {node}")
+        logger.info(f"Parsing node: {node}")
         for prop in model_parsed.get_node_props_list(node):
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in node_list:
-        print(f"Parsing relationships for node: {node}")
+        logger.info(f"Parsing relationships for node: {node}")
         parent_nodes = model_parsed.get_parent_nodes(node)
-        print(f"Parent nodes of node: {node} are: {parent_nodes}")
+        logger.info(f"Parent nodes of node: {node} are: {parent_nodes}")
         if len(parent_nodes) == 0:
-            print(f"Node: {node} has no parent nodes, skipping relationship parsing for this node.")
+            logger.info(
+                f"Node: {node} has no parent nodes, skipping relationship parsing for this node."
+            )
         else:
-            print(
+            logger.info(
                 f"Node: {node} has parent nodes, parsing relationships for this node."
             )
             for parent in parent_nodes:
                 key_prop = model_parsed.get_node_key_prop(parent)
                 if not key_prop:
-                    print(f"No key_prop found for parent '{parent}' of node '{node}', skipping.")
+                    logger.warning(
+                        f"No key_prop found for parent '{parent}' of node '{node}', skipping."
+                    )
                     continue
-                rows.append({"node": node, "property": f"{parent}.{key_prop}", "version": version})
+                rows.append(
+                    {
+                        "node": node,
+                        "property": f"{parent}.{key_prop}",
+                        "version": version,
+                    }
+                )
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])
 
 
 # ── merging ───────────────────────────────────────────────────────────────────
+
 
 def build_mapping(df_from: pd.DataFrame, df_to: pd.DataFrame) -> pd.DataFrame:
     merged = pd.merge(
@@ -81,11 +99,50 @@ def build_mapping(df_from: pd.DataFrame, df_to: pd.DataFrame) -> pd.DataFrame:
     return merged[COLUMNS]
 
 
+# ── reconciliation ────────────────────────────────────────────────────────────
+
+
+def reconcile_mapping(
+    mapping_provided: pd.DataFrame, mapping_built: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Reconcile a user-provided mapping file against a freshly built one.
+    - Rows in the provided file take precedence (they contain curated mappings).
+    - Rows in the built file that are already covered by the provided file are dropped.
+    - Rows in the built file that are NOT covered are appended (net-new nodes/properties).
+    A row is considered "covered" if its lift_from_node + lift_from_property pair
+    already exists in the provided mapping.
+    """
+    provided_keys = set(
+        zip(mapping_provided["lift_from_node"], mapping_provided["lift_from_property"])
+    )
+
+    # only keep built rows whose from-key isn't already handled in the provided file
+    net_new = mapping_built[
+        ~mapping_built.apply(
+            lambda row: (row["lift_from_node"], row["lift_from_property"])
+            in provided_keys,
+            axis=1,
+        )
+    ]
+
+    reconciled = pd.concat([mapping_provided, net_new], ignore_index=True)
+    return reconciled
+
+
 # ── user input ────────────────────────────────────────────────────────────────
 
-def user_input_location(df, value_node_col, value_property_col,
-                        missing_node_col, missing_property_col,
-                        missing_version_col, base_mode, direction):
+
+def user_input_location(
+    df,
+    value_node_col,
+    value_property_col,
+    missing_node_col,
+    missing_property_col,
+    missing_version_col,
+    base_mode,
+    direction,
+):
     logger = get_run_logger()
 
     df_missing = df[df[missing_property_col].isna()]
@@ -97,10 +154,13 @@ def user_input_location(df, value_node_col, value_property_col,
         if base_mode:
             user_input_node = user_input_prop = "remove"
         else:
-            header = "Old values to map to new" if direction == "fromto" else "New values to map to old"
+            header = (
+                "Old values to map to new"
+                if direction == "fromto"
+                else "New values to map to old"
+            )
             value_inputs = pause_flow_run(
-                wait_for_input=InputValues.with_initial_data(
-                    description=f"""
+                wait_for_input=InputValues.with_initial_data(description=f"""
 # **Active Input**
 
 ## **Instructions**
@@ -111,10 +171,11 @@ def user_input_location(df, value_node_col, value_property_col,
 ## **{header}**
 **node**: {existing_node}
 **property**: {existing_property}
-                    """
-                )
+                    """)
             )
-            logger.info(f"Inputs received:\nnode: {value_inputs.node}\nproperty: {value_inputs.property}")
+            logger.info(
+                f"Inputs received:\nnode: {value_inputs.node}\nproperty: {value_inputs.property}"
+            )
             user_input_node = value_inputs.node
             user_input_prop = value_inputs.property
 
@@ -135,6 +196,7 @@ def user_input_location(df, value_node_col, value_property_col,
 
 # ── cleanup ───────────────────────────────────────────────────────────────────
 
+
 def expand_semicolon_nodes(df: pd.DataFrame) -> pd.DataFrame:
     rows = []
     for _, row in df.iterrows():
@@ -149,33 +211,38 @@ def expand_semicolon_nodes(df: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows).reset_index(drop=True)
 
 
-def clean_up_partial_dups(df, empty_node_col, empty_prop_col,
-                        value_node_col, value_prop_col) -> pd.DataFrame:
+def clean_up_partial_dups(
+    df, empty_node_col, empty_prop_col, value_node_col, value_prop_col
+) -> pd.DataFrame:
     indexes_to_remove = []
     for index, row in df.iterrows():
         if pd.isna(row[empty_node_col]) or pd.isna(row[empty_prop_col]):
-            mask = (
-                (df[value_node_col] == df.at[index, value_node_col]) &
-                (df[value_prop_col] == df.at[index, value_prop_col])
+            mask = (df[value_node_col] == df.at[index, value_node_col]) & (
+                df[value_prop_col] == df.at[index, value_prop_col]
             )
             matching = df.index[mask].tolist()
             if len(matching) > 1:
                 for other_index in matching:
                     other = df.iloc[other_index]
-                    if pd.isna(other[empty_node_col]) and pd.isna(other[empty_prop_col]):
+                    if pd.isna(other[empty_node_col]) and pd.isna(
+                        other[empty_prop_col]
+                    ):
                         indexes_to_remove.append(index)
     return df.drop(list(set(indexes_to_remove))).fillna("")
 
 
 # ── comparison ────────────────────────────────────────────────────────────────
 
-def build_comparison(df: pd.DataFrame, old_version: str, new_version: str) -> pd.DataFrame:
+
+def build_comparison(
+    df: pd.DataFrame, old_version: str, new_version: str
+) -> pd.DataFrame:
     results = []
     for _, row in df.iterrows():
         from_vals = (row["lift_from_node"], row["lift_from_property"])
-        to_vals   = (row["lift_to_node"],   row["lift_to_property"])
+        to_vals = (row["lift_to_node"], row["lift_to_property"])
         from_na = any(v == "" for v in from_vals)
-        to_na   = any(v == "" for v in to_vals)
+        to_na = any(v == "" for v in to_vals)
 
         if to_na and not from_na:
             state = "DELETION"
@@ -186,25 +253,23 @@ def build_comparison(df: pd.DataFrame, old_version: str, new_version: str) -> pd
         else:
             state = "SAME"
 
-        results.append({
-            "state":              state,
-            "lift_from_node":     from_vals[0],
-            "lift_from_property": from_vals[1],
-            "lift_from_version":  old_version,
-            "lift_to_node":       to_vals[0],
-            "lift_to_property":   to_vals[1],
-            "lift_to_version":    new_version,
-        })
+        results.append(
+            {
+                "state": state,
+                "lift_from_node": from_vals[0],
+                "lift_from_property": from_vals[1],
+                "lift_from_version": old_version,
+                "lift_to_node": to_vals[0],
+                "lift_to_property": to_vals[1],
+                "lift_to_version": new_version,
+            }
+        )
 
-    return (
-        pd.DataFrame(results)
-        .query("state != 'SAME'")
-        .fillna("")
-        .drop_duplicates()
-    )
+    return pd.DataFrame(results).query("state != 'SAME'").fillna("").drop_duplicates()
 
 
 # ── main flow ─────────────────────────────────────────────────────────────────
+
 
 @flow(
     name="Model Mapping Maker",
@@ -226,63 +291,136 @@ def runner(
     output_folder = os.path.join(runner, "model_mapping_maker_" + current_date)
 
     # if mapping file path is not updated from default or is empty, skip downloading and instead build mapping from scratch
-    if mapping_file == "path_to/mapping_file/in/s3_bucket.tsv" or mapping_file.strip() == "":
+    if (
+        mapping_file == "path_to/mapping_file/in/s3_bucket.tsv"
+        or mapping_file.strip() == ""
+    ):
         mapping_file = None
     if mapping_file:
         file_dl(bucket, mapping_file)
 
     # ── fetch models ──────────────────────────────────────────────────────────
 
-    old_model_file_yaml = pull_model_data_files(model=old_model_repository, version=old_model_version, file_type="model", output_file="old_model.yaml")
+    old_model_file_yaml = pull_model_data_files(
+        model=old_model_repository,
+        version=old_model_version,
+        file_type="model",
+        output_file="old_model.yaml",
+    )
     logger.info(f"{old_model_repository} at {old_model_version} found.")
-    
-    old_props_file_yaml = pull_model_data_files(model=old_model_repository, version=old_model_version, file_type="props", output_file="old_props.yaml")
-    logger.info(f"{old_model_repository} properties at {old_model_version} found.")
-        
-    new_model_file_yaml = pull_model_data_files(model=new_model_repository, version=new_model_version, file_type="model", output_file="new_model.yaml")
-    logger.info(f"{new_model_repository} at {new_model_version} found.")    
-    
-    new_props_file_yaml = pull_model_data_files(model=new_model_repository, version=new_model_version, file_type="props", output_file="new_props.yaml")
-    logger.info(f"{new_model_repository} properties at {new_model_version} found.")
 
+    old_props_file_yaml = pull_model_data_files(
+        model=old_model_repository,
+        version=old_model_version,
+        file_type="props",
+        output_file="old_props.yaml",
+    )
+    logger.info(f"{old_model_repository} properties at {old_model_version} found.")
+
+    new_model_file_yaml = pull_model_data_files(
+        model=new_model_repository,
+        version=new_model_version,
+        file_type="model",
+        output_file="new_model.yaml",
+    )
+    logger.info(f"{new_model_repository} at {new_model_version} found.")
+
+    new_props_file_yaml = pull_model_data_files(
+        model=new_model_repository,
+        version=new_model_version,
+        file_type="props",
+        output_file="new_props.yaml",
+    )
+    logger.info(f"{new_model_repository} properties at {new_model_version} found.")
 
     # ── Create MDF objects via MEVAL (mdf) parsing ─────────────────────────────────
     model_parsed_old = ModelParser(
         model_file=old_model_file_yaml,
         props_file=old_props_file_yaml,
-        handle=old_model_version
+        handle=old_model_version,
     )
 
     model_parsed_new = ModelParser(
         model_file=new_model_file_yaml,
         props_file=new_props_file_yaml,
-        handle=new_model_version
+        handle=new_model_version,
     )
 
     df_old = parse_model(model_parsed_old, old_model_version)
     df_new = parse_model(model_parsed_new, new_model_version)
 
-
     # ── build or load mapping ─────────────────────────────────────────────────
-    if mapping_file:
-        mapping_df = pd.read_csv(os.path.basename(mapping_file), sep="\t")
-        mapping_df.columns = COLUMNS
-    else:
-        df_from = df_old.rename(columns={"node": "lift_from_node", "property": "lift_from_property", "version": "lift_from_version"})
-        df_to   = df_new.rename(columns={"node": "lift_to_node",   "property": "lift_to_property",   "version": "lift_to_version"})
 
-        mapping_df = build_mapping(df_from, df_to)
+    # always build a fresh mapping from the parsed models
+    df_from = df_old.rename(
+        columns={
+            "node": "lift_from_node",
+            "property": "lift_from_property",
+            "version": "lift_from_version",
+        }
+    )
+    df_to = df_new.rename(
+        columns={
+            "node": "lift_to_node",
+            "property": "lift_to_property",
+            "version": "lift_to_version",
+        }
+    )
+    mapping_built = build_mapping(df_from, df_to)
+
+    if mapping_file:
+        mapping_provided = pd.read_csv(os.path.basename(mapping_file), sep="\t")
+        mapping_provided.columns = COLUMNS
+        mapping_df = reconcile_mapping(mapping_provided, mapping_built)
+        logger.info(
+            f"Reconciled provided mapping with freshly built mapping. "
+            f"Provided: {len(mapping_provided)} rows, "
+            f"Built: {len(mapping_built)} rows, "
+            f"Reconciled: {len(mapping_df)} rows."
+        )
+    else:
+        mapping_df = mapping_built
 
     if not base_mode:
-        user_input_location(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property",   "lift_to_version",   base_mode, "fromto")
-        user_input_location(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property", "lift_from_version", base_mode, "tofrom")
+        user_input_location(
+            mapping_df,
+            "lift_from_node",
+            "lift_from_property",
+            "lift_to_node",
+            "lift_to_property",
+            "lift_to_version",
+            base_mode,
+            "fromto",
+        )
+        user_input_location(
+            mapping_df,
+            "lift_to_node",
+            "lift_to_property",
+            "lift_from_node",
+            "lift_from_property",
+            "lift_from_version",
+            base_mode,
+            "tofrom",
+        )
 
         mapping_df = mapping_df.drop_duplicates()
 
     # ── post-process ──────────────────────────────────────────────────────────
     mapping_df = expand_semicolon_nodes(mapping_df)
-    mapping_df = clean_up_partial_dups(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property")
-    mapping_df = clean_up_partial_dups(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property")
+    mapping_df = clean_up_partial_dups(
+        mapping_df,
+        "lift_from_node",
+        "lift_from_property",
+        "lift_to_node",
+        "lift_to_property",
+    )
+    mapping_df = clean_up_partial_dups(
+        mapping_df,
+        "lift_to_node",
+        "lift_to_property",
+        "lift_from_node",
+        "lift_from_property",
+    )
 
     mapping_df = mapping_df.fillna("").drop_duplicates()
 
@@ -294,10 +432,20 @@ def runner(
 
     mapping_file_name = f"{prefix}_MAPPING_{current_date}.tsv"
     mapping_df.to_csv(mapping_file_name, sep="\t", index=False)
-    file_ul(bucket=bucket, output_folder=output_folder, sub_folder="", newfile=mapping_file_name)
+    file_ul(
+        bucket=bucket,
+        output_folder=output_folder,
+        sub_folder="",
+        newfile=mapping_file_name,
+    )
 
     comparison_file_name = f"{prefix}_comparison_{current_date}.tsv"
     comparison_df.to_csv(comparison_file_name, sep="\t", index=False)
-    file_ul(bucket=bucket, output_folder=output_folder, sub_folder="", newfile=comparison_file_name)
+    file_ul(
+        bucket=bucket,
+        output_folder=output_folder,
+        sub_folder="",
+        newfile=comparison_file_name,
+    )
 
     logger.info(f"Done. Outputs written to {output_folder}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -73,33 +73,6 @@ def parse_model(model_parsed, version):
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])
 
-# def extract_properties(yaml_data, side: str) -> pd.DataFrame:
-#     """side is either 'from' or 'to'."""
-#     version = get_version(yaml_data)
-#     rows = [
-#         {f"lift_{side}_node": node, f"lift_{side}_property": prop, f"lift_{side}_version": version}
-#         for node, props in yaml_data["Nodes"].items()
-#         for prop in props["Props"]
-#     ]
-#     return pd.DataFrame(rows)
-
-
-# def extract_relationships(yaml_data, side: str) -> pd.DataFrame:
-#     """side is either 'from' or 'to'."""
-#     version = get_version(yaml_data)
-#     rows = [
-#         {
-#             f"lift_{side}_node": src,
-#             f"lift_{side}_property": f"{dst}.{dst}_id",
-#             f"lift_{side}_version": version,
-#         }
-#         for rel in yaml_data["Relationships"].values()
-#         for ends in rel["Ends"]
-#         for src, dst in [(ends.get("Src"), ends.get("Dst"))]
-#         if src and dst
-#     ]
-#     return pd.DataFrame(rows)
-
 
 # ── merging ───────────────────────────────────────────────────────────────────
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -1,17 +1,10 @@
-# model_mapping_maker
-
 import yaml
 import requests
 import pandas as pd
-from datetime import date
 import os
 from prefect import flow, get_run_logger, pause_flow_run
 from prefect.input import RunInput
-from src.utils import (
-    get_time,
-    file_dl,
-    file_ul,
-)
+from src.utils import get_time, file_dl, file_ul
 
 
 class InputValues(RunInput):
@@ -19,256 +12,192 @@ class InputValues(RunInput):
     property: str
 
 
-# obtain the date
-def refresh_date():
-    today = date.today()
-    today = today.strftime("%Y%m%d")
-    return today
+COLUMNS = [
+    "lift_from_node", "lift_from_property", "lift_from_version",
+    "lift_to_node",   "lift_to_property",   "lift_to_version",
+]
 
+# ── helpers ───────────────────────────────────────────────────────────────────
 
 def read_yaml_from_github(url):
-    # Fetch the content of the file from the given URL
     response = requests.get(url)
-    response.raise_for_status()  # Raise an HTTPError for bad responses
-
-    # Load the YAML content
-    yaml_content = yaml.safe_load(response.text)
-
-    return yaml_content
+    response.raise_for_status()
+    return yaml.safe_load(response.text)
 
 
-@flow(
-    name="Extract_properties",
-    log_prints=True,
-)
-def extract_properties(yaml_data):
-    properties = []
-
-    if "Version" in yaml_data:
-        version = yaml_data["Version"]
-        version_update = version.replace("v.", "").replace("v", "")
-
-    else:
-        version_update = "insert version"
-
-    for Nodes, Props in yaml_data["Nodes"].items():
-        for Prop in Props["Props"]:
-            properties.append(
-                {"node": Nodes, "property": Prop, "version": version_update}
-            )
-
-    return pd.DataFrame(properties)
+def get_version(yaml_data):
+    version = yaml_data.get("Version", "insert version")
+    return version.replace("v.", "").replace("v", "")
 
 
-@flow(
-    name="Extract_relationships",
-    log_prints=True,
-)
-def extract_relationships(yaml_data):
+# ── extraction ────────────────────────────────────────────────────────────────
 
-    relationships = []
-
-    if "Version" in yaml_data:
-        version = yaml_data["Version"]
-        version_update = version.replace("v.", "").replace("v", "")
-
-    else:
-        version_update = "insert version"
-
-    for relationship in yaml_data["Relationships"].items():
-        relationship = relationship[1]["Ends"]
-
-        for ends in relationship:
-            src = ends.get("Src")
-            dst = ends.get("Dst")
-            relationships.append({"Src": src, "Dst": dst, "version": version_update})
-
-    return pd.DataFrame(relationships)
+def extract_properties(yaml_data, side: str) -> pd.DataFrame:
+    """side is either 'from' or 'to'."""
+    version = get_version(yaml_data)
+    rows = [
+        {f"lift_{side}_node": node, f"lift_{side}_property": prop, f"lift_{side}_version": version}
+        for node, props in yaml_data["Nodes"].items()
+        for prop in props["Props"]
+    ]
+    return pd.DataFrame(rows)
 
 
-@flow(
-    name="Source_Destination_to_Node_Properties",
-    log_prints=True,
-)
-def src_dst_to_node_prop(df, src_col, dst_col):
-    # quick logic to determine if the node / prop column is new or old.
-    if "old" in src_col.lower():
-        node = "node_old"
-    else:
-        node = "node_new"
-
-    if "old" in dst_col.lower():
-        property = "property_old"
-    else:
-        property = "property_new"
-
-    # for each row create a node / prop_id entry based on the src / dst mapping.
-    for index, row in df.iterrows():
-        if pd.isna(df.at[index, src_col]) or pd.isna(df.at[index, dst_col]):
-            df.at[index, node] = None
-            df.at[index, property] = None
-        else:
-            df.at[index, node] = df.at[index, src_col]
-            df.at[index, property] = f"{df.at[index,dst_col]}.{df.at[index,dst_col]}_id"
-
-    return df
+def extract_relationships(yaml_data, side: str) -> pd.DataFrame:
+    """side is either 'from' or 'to'."""
+    version = get_version(yaml_data)
+    rows = [
+        {
+            f"lift_{side}_node": src,
+            f"lift_{side}_property": f"{dst}.{dst}_id",
+            f"lift_{side}_version": version,
+        }
+        for rel in yaml_data["Relationships"].values()
+        for ends in rel["Ends"]
+        for src, dst in [(ends.get("Src"), ends.get("Dst"))]
+        if src and dst
+    ]
+    return pd.DataFrame(rows)
 
 
-def clean_up_partial_dups(
-    df, empty_col_node, empty_col_prop, value_col_node, value_col_prop
-):
-    # Do final fixes to remove new mappings that have been accounted for.
-    indexes_to_remove = []
-    for index, row in df.iterrows():
-        # if the old node or property is blank
-        if pd.isna(row[empty_col_node]) or pd.isna(row[empty_col_prop]):
+# ── merging ───────────────────────────────────────────────────────────────────
 
-            # look at the new node and property
-            new_node_value = df.at[index, value_col_node]
-            new_property_value = df.at[index, value_col_prop]
-
-            # then create a filter that looks for any other instances where there are duplicates of the new node/property value found in other places.
-            mask = (df[value_col_node] == new_node_value) & (
-                df[value_col_prop] == new_property_value
-            )
-
-            # add those indexes of duplicate new node/property values to a list
-            indexes = df.index[mask].tolist()
-
-            # If other instances exist for this, see if there is a conversion from an older version
-            # If there is, then remove this blanked version for the new node and property.
-            if len(indexes) > 1:
-                for other_index in indexes:
-                    other_row = df.iloc[other_index]
-                    if pd.isna(other_row[empty_col_node]) and pd.isna(
-                        other_row[empty_col_prop]
-                    ):
-                        indexes_to_remove.append(index)
-                        indexes_to_remove = list(set(indexes_to_remove))
-
-            else:
-                pass
-
-    # remove redundant or incomplete rows compared to already existing rows
-    df = df.drop(indexes_to_remove)
-    df = df.fillna("")
-
-    return df
+def build_mapping(df_from: pd.DataFrame, df_to: pd.DataFrame) -> pd.DataFrame:
+    merged = pd.merge(
+        df_from,
+        df_to,
+        left_on=["lift_from_node", "lift_from_property"],
+        right_on=["lift_to_node", "lift_to_property"],
+        how="outer",
+    )
+    return merged[COLUMNS]
 
 
-# user determines where deleted properties go
-def user_input_location(
-    df,
-    value_node_col,
-    value_property_col,
-    missing_node_col,
-    missing_property_col,
-    missing_version_col,
-    base_mode,
-    direction,
-):
-    runner_logger = get_run_logger()
+# ── user input ────────────────────────────────────────────────────────────────
 
-    if base_mode:
-        runner_logger.info("You are running in base mode, no need for input.")
-    else:
-        runner_logger.info("You are not running in base mode, input needed.")
+def user_input_location(df, value_node_col, value_property_col,
+                         missing_node_col, missing_property_col,
+                         missing_version_col, base_mode, direction):
+    logger = get_run_logger()
 
-    # looking at the missing values in one column, determine values to map to each node and property.
     df_missing = df[df[missing_property_col].isna()]
-    # for each row with missing information in the column of interest
     for index, row in df_missing.iterrows():
         existing_node = row[value_node_col]
         existing_property = row[value_property_col]
-        runner_logger.info(
-            f"{index}. node: {existing_node}, property: {existing_property}"
-        )
+        logger.info(f"{index}. node: {existing_node}, property: {existing_property}")
 
-        # if in base mode, skip inputs and keep it all blank
         if base_mode:
-            user_input_node = "remove"
-            user_input_prop = "remove"
-        # else, allow user input
+            user_input_node = user_input_prop = "remove"
         else:
-            if direction == "oldnew":
-                value_inputs = pause_flow_run(
-                    wait_for_input=InputValues.with_initial_data(
-                        description=f"""
+            header = "Old values to map to new" if direction == "fromto" else "New values to map to old"
+            value_inputs = pause_flow_run(
+                wait_for_input=InputValues.with_initial_data(
+                    description=f"""
 # **Active Input**
 
 ## **Instructions**
-
-If these values were moved to a new location, please enter the new node and/or property.
-
 - If a value is staying the same, write 'same'.
 - If a value is removed, write 'remove'.
+- For multiple nodes, use ';' as separator.
 
-- **node**: the new node/nodes the property is located in. For lists, use ';' as the separator.
-- **property**: the new property name.
-
-## **Old values to map to new**
-
+## **{header}**
 **node**: {existing_node}
 **property**: {existing_property}
-                            """
-                    )
+                    """
                 )
-            elif direction == "newold":
-                value_inputs = pause_flow_run(
-                    wait_for_input=InputValues.with_initial_data(
-                        description=f"""
-# **Active Input**
-
-## **Instructions**
-
-If these values are being pulled from an older location, please enter the old node and/or property.
-
-- If a value is staying the same, write 'same'.
-- If a value is removed, write 'remove'.
-
-- **node**: the old node/nodes the property is located in.
-- **property**: the old property name.
-
-## **New values to map to old**
-
-**node**: {existing_node}
-**property**: {existing_property}
-                            """
-                    )
-                )
-
-            runner_logger.info(
-                "Inputs received:"
-                + "\n"
-                + f"node: {value_inputs.node}"
-                + "\n"
-                + f"property: {value_inputs.property}"
             )
+            logger.info(f"Inputs received:\nnode: {value_inputs.node}\nproperty: {value_inputs.property}")
             user_input_node = value_inputs.node
             user_input_prop = value_inputs.property
 
-        # make things easier, if it is the same value, say "same".
         if user_input_node.lower() == "same":
             user_input_node = row[value_node_col]
         if user_input_prop.lower() == "same":
             user_input_prop = row[value_property_col]
-
-        # make things easier, if it is no longer needed, ignore and leave blank.
         if user_input_node.lower() == "remove":
             user_input_node = None
         if user_input_prop.lower() == "remove":
             user_input_prop = None
 
-        # obtain the model version based on the input missing column
-        new_model_version = df[missing_version_col].dropna().unique()[0]
-
-        # apply values to the data frame
+        new_version = df[missing_version_col].dropna().unique()[0]
         df.at[index, missing_node_col] = user_input_node
         df.at[index, missing_property_col] = user_input_prop
-        df.at[index, missing_version_col] = new_model_version
+        df.at[index, missing_version_col] = new_version
 
 
-# Here is the main flow of the script
+# ── cleanup ───────────────────────────────────────────────────────────────────
+
+def expand_semicolon_nodes(df: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for _, row in df.iterrows():
+        node_to = row["lift_to_node"]
+        if pd.isna(node_to) or node_to in ["NA", "none", ""]:
+            rows.append(row)
+        else:
+            for value in node_to.split(";"):
+                new_row = row.copy()
+                new_row["lift_to_node"] = value.strip()
+                rows.append(new_row)
+    return pd.DataFrame(rows).reset_index(drop=True)
+
+
+def clean_up_partial_dups(df, empty_node_col, empty_prop_col,
+                           value_node_col, value_prop_col) -> pd.DataFrame:
+    indexes_to_remove = []
+    for index, row in df.iterrows():
+        if pd.isna(row[empty_node_col]) or pd.isna(row[empty_prop_col]):
+            mask = (
+                (df[value_node_col] == df.at[index, value_node_col]) &
+                (df[value_prop_col] == df.at[index, value_prop_col])
+            )
+            matching = df.index[mask].tolist()
+            if len(matching) > 1:
+                for other_index in matching:
+                    other = df.iloc[other_index]
+                    if pd.isna(other[empty_node_col]) and pd.isna(other[empty_prop_col]):
+                        indexes_to_remove.append(index)
+    return df.drop(list(set(indexes_to_remove))).fillna("")
+
+
+# ── comparison ────────────────────────────────────────────────────────────────
+
+def build_comparison(df: pd.DataFrame, old_version: str, new_version: str) -> pd.DataFrame:
+    results = []
+    for _, row in df.iterrows():
+        from_vals = (row["lift_from_node"], row["lift_from_property"])
+        to_vals   = (row["lift_to_node"],   row["lift_to_property"])
+        from_na = any(v == "" for v in from_vals)
+        to_na   = any(v == "" for v in to_vals)
+
+        if to_na and not from_na:
+            state = "DELETION"
+        elif from_na and not to_na:
+            state = "ADDITION"
+        elif from_vals != to_vals:
+            state = "CHANGED"
+        else:
+            state = "SAME"
+
+        results.append({
+            "state":              state,
+            "lift_from_node":     from_vals[0],
+            "lift_from_property": from_vals[1],
+            "lift_from_version":  old_version,
+            "lift_to_node":       to_vals[0],
+            "lift_to_property":   to_vals[1],
+            "lift_to_version":    new_version,
+        })
+
+    return (
+        pd.DataFrame(results)
+        .query("state != 'SAME'")
+        .fillna("")
+        .drop_duplicates()
+    )
+
+
+# ── main flow ─────────────────────────────────────────────────────────────────
+
 @flow(
     name="Model Mapping Maker",
     log_prints=True,
@@ -284,363 +213,64 @@ def runner(
     old_model_file_location: str = "model-desc/ccdi-model.yml",
     new_model_file_location: str = "model-desc/ccdi-model.yml",
     base_mode: bool = False,
-    nodes_mapping_file: str = "path_to/nodes_file/in/s3_bucket",
-    relationship_mapping_file: str = "path_to/nodes_file/in/s3_bucket",
+    mapping_file: str = "path_to/mapping_file/in/s3_bucket.tsv",
 ):
+    logger = get_run_logger()
+    current_date = get_time()
+    output_folder = os.path.join(runner, "model_mapping_maker_" + current_date)
 
-    # Output column names
-    output_column_names = [
-        "lift_from_node",
-        "lift_from_property",
-        "lift_from_version",
-        "lift_to_node",
-        "lift_to_property",
-        "lift_to_version",
-    ]
+    # if mapping file path is not updated from default or is empty, skip downloading and instead build mapping from scratch
+    if mapping_file == "path_to/mapping_file/in/s3_bucket.tsv" or mapping_file.strip() == "":
+        mapping_file = None
+    if mapping_file:
+        file_dl(bucket, mapping_file)
 
-    # Input column names for nodes and relationships
-    input_column_names = [
-        "node_old",
-        "property_old",
-        "version_old",
-        "node_new",
-        "property_new",
-        "version_new",
-    ]
+    # ── fetch models ──────────────────────────────────────────────────────────
+    old_url = f"https://raw.githubusercontent.com/CBIIT/{old_model_repository}/{old_model_version}/{old_model_file_location}"
+    new_url = f"https://raw.githubusercontent.com/CBIIT/{new_model_repository}/{new_model_version}/{new_model_file_location}"
 
-    # create a logging object
-    runner_logger = get_run_logger()
+    yaml_old = read_yaml_from_github(old_url)
+    logger.info(f"{old_model_repository} at {old_model_version} found.")
+    yaml_new = read_yaml_from_github(new_url)
+    logger.info(f"{new_model_repository} at {new_model_version} found.")
 
-    # Null out the suggested file path if not overwritten
-    if nodes_mapping_file == "path_to/nodes_file/in/s3_bucket":
-        nodes_mapping_file = None
-    if relationship_mapping_file == "path_to/nodes_file/in/s3_bucket":
-        relationship_mapping_file = None
-
-    # download the configuration file inputs if they are given.
-    if nodes_mapping_file:
-        file_dl(bucket, nodes_mapping_file)
-    if relationship_mapping_file:
-        file_dl(bucket, relationship_mapping_file)
-
-    # EVERYTHING
-
-    # obtain date
-    current_date = refresh_date()
-
-    # URL of the raw YAML file on GitHub
-    new_model_url = f"https://raw.githubusercontent.com/CBIIT/{new_model_repository}/{new_model_version}/{new_model_file_location}"
-    old_model_url = f"https://raw.githubusercontent.com/CBIIT/{old_model_repository}/{old_model_version}/{old_model_file_location}"
-
-    # Read the YAML content from the URL
-    yaml_content_new = read_yaml_from_github(new_model_url)
-    runner_logger.info(f"{new_model_repository} at {new_model_version} found.")
-    yaml_content_old = read_yaml_from_github(old_model_url)
-    runner_logger.info(f"{old_model_repository} at {old_model_version} found.")
-
-    # Extract properties from the YAML data
-    df_new = extract_properties(yaml_content_new)
-    df_old = extract_properties(yaml_content_old)
-
-    df_new.columns = ["node_new", "property_new", "version_new"]
-    df_old.columns = ["node_old", "property_old", "version_old"]
-
-    # Merge the dataframes with outer join
-    merged_df = pd.merge(
-        df_old,
-        df_new,
-        left_on=["node_old", "property_old"],
-        right_on=["node_new", "property_new"],
-        how="outer",
-    )
-
-    # Extract relationships from the YAML data
-    relationships_new = extract_relationships(yaml_content_new)
-    relationships_old = extract_relationships(yaml_content_old)
-
-    relationships_new.columns = ["src_new", "dst_new", "version_new"]
-    relationships_old.columns = ["src_old", "dst_old", "version_old"]
-
-    # Merge the dataframes with outer join
-    merged_df_relate = pd.merge(
-        relationships_old,
-        relationships_new,
-        left_on=["src_old", "dst_old"],
-        right_on=["src_new", "dst_new"],
-        how="outer",
-    )
-
-    # convert source/destination values into node/property values
-    merged_df_relate = src_dst_to_node_prop(merged_df_relate, "src_old", "dst_old")
-    merged_df_relate = src_dst_to_node_prop(merged_df_relate, "src_new", "dst_new")
-
-    # get rid of old columns
-    merged_df_relate.drop(
-        columns=["src_old", "dst_old", "src_new", "dst_new"], inplace=True
-    )
-
-    # if there isn't an input file, run through asking for input
-    if not nodes_mapping_file:
-        # Take input to create the base mapping file for nodes and properties
-        user_input_location(
-            merged_df,
-            "node_old",
-            "property_old",
-            "node_new",
-            "property_new",
-            "version_new",
-            base_mode,
-            "oldnew",
-        )
-    # use the mapping file
+    # ── build or load mapping ─────────────────────────────────────────────────
+    if mapping_file:
+        mapping_df = pd.read_csv(os.path.basename(mapping_file), sep="\t")
+        mapping_df.columns = COLUMNS
     else:
-        merged_df = pd.read_csv(os.path.basename(nodes_mapping_file), sep="\t")
-        merged_df.columns = input_column_names
+        props_df = build_mapping(extract_properties(yaml_old, "from"), extract_properties(yaml_new, "to"))
+        rels_df  = build_mapping(extract_relationships(yaml_old, "from"), extract_relationships(yaml_new, "to"))
+        mapping_df = pd.concat([props_df, rels_df], ignore_index=True)
 
-    # Create new df based on input for the diffs that were noted.
-    new_merged = []
+        user_input_location(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property",   "lift_to_version",   base_mode, "fromto")
+        user_input_location(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property", "lift_from_version", base_mode, "tofrom")
 
-    # for the property node mapping file, clean it up
-    for index, row in merged_df.iterrows():
-        # Add rows where 'node_new' is NA or None
-        if pd.isna(row["node_new"]) or row["node_new"] in ["NA", "none"]:
-            new_row = row.copy()
-            new_merged.append(new_row)
-        else:
-            # check for node values that are a list and split them out
-            node_values = (
-                row["node_new"].split(";")
-                if ";" in row["node_new"]
-                else [row["node_new"]]
-            )
-            first_value = True
-            for value in node_values:
-                if first_value:
-                    # Add the original row with the first split value
-                    new_row = row.copy()
-                    new_row["node_new"] = value
-                    new_merged.append(new_row)
-                    first_value = False
-                else:
-                    # Add new rows with subsequent split values
-                    new_row = row.copy()
-                    new_row["node_new"] = value
-                    new_merged.append(new_row)
+        mapping_df = mapping_df.drop_duplicates()
 
-    # Create a new DataFrame from the new rows
-    new_merged_df = pd.DataFrame(new_merged)
+    # ── post-process ──────────────────────────────────────────────────────────
+    mapping_df = expand_semicolon_nodes(mapping_df)
+    mapping_df = clean_up_partial_dups(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property")
+    mapping_df = clean_up_partial_dups(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property")
 
-    # Reset the index of the new DataFrame
-    new_merged_df.reset_index(drop=True, inplace=True)
+    for ver_col, yaml_data in [("lift_from_version", yaml_old), ("lift_to_version", yaml_new)]:
+        if mapping_df[ver_col].replace("", pd.NA).isna().any():
+            mapping_df[ver_col] = get_version(yaml_data)
 
-    # Do final fixes to remove new mappings that have been accounted for.
-    new_merged_df = clean_up_partial_dups(
-        new_merged_df, "node_old", "property_old", "node_new", "property_new"
-    )
+    mapping_df = mapping_df.fillna("").drop_duplicates()
 
-    # fix version columns, because the check is only one way, old to new,
-    # it doesn't know about columns that have new values but no value for the old one,
-    # thus it doesn't fill in the old version number
-    new_merged_df["version_old"] = (
-        new_merged_df["version_old"].dropna().unique().tolist()[0]
-    )
+    # ── comparison ────────────────────────────────────────────────────────────
+    comparison_df = build_comparison(mapping_df, old_model_version, new_model_version)
 
-    # UPLOAD NODES file
+    # ── save & upload ─────────────────────────────────────────────────────────
+    prefix = f"{old_model_repository}_{old_model_version}_{new_model_repository}_{new_model_version}"
 
-    output_folder = os.path.join(runner, "model_mapping_maker_" + get_time())
+    mapping_file_name = f"{prefix}_MAPPING_{current_date}.tsv"
+    mapping_df.to_csv(mapping_file_name, sep="\t", index=False)
+    file_ul(bucket=bucket, output_folder=output_folder, sub_folder="", newfile=mapping_file_name)
 
-    # final setup to make sure that [node].[node]_ids get moved when a property moves from
-    # one node to a new node, especially an established node, it is likely this is needed.
+    comparison_file_name = f"{prefix}_comparison_{current_date}.tsv"
+    comparison_df.to_csv(comparison_file_name, sep="\t", index=False)
+    file_ul(bucket=bucket, output_folder=output_folder, sub_folder="", newfile=comparison_file_name)
 
-    if not relationship_mapping_file:
-        # Take inputs for relationship values that are found in the old model but are not located in the new model.
-        user_input_location(
-            merged_df_relate,
-            "node_old",
-            "property_old",
-            "node_new",
-            "property_new",
-            "version_new",
-            base_mode,
-            "oldnew",
-        )
-
-        # Take inputs for relationship values that are found in the new model but are not located in the old model.
-        user_input_location(
-            merged_df_relate,
-            "node_new",
-            "property_new",
-            "node_old",
-            "property_old",
-            "version_old",
-            base_mode,
-            "newold",
-        )
-
-        merged_df_relate = merged_df_relate.drop_duplicates()
-
-    else:
-        merged_df_relate = pd.read_csv(
-            os.path.basename(relationship_mapping_file), sep="\t"
-        )
-        # convert to input column names
-        merged_df_relate.columns = input_column_names
-
-    # Do final fixes to remove new mappings that have been accounted for.
-    merged_df_relate = clean_up_partial_dups(
-        merged_df_relate, "node_old", "property_old", "node_new", "property_new"
-    )
-    merged_df_relate = clean_up_partial_dups(
-        merged_df_relate, "node_new", "property_new", "node_old", "property_old"
-    )
-
-    # reorder relationship df to match the node property one.
-    merged_df_relate = merged_df_relate[new_merged_df.columns]
-    merged_df_relate = merged_df_relate.fillna("")
-
-    # Create concatenation of mapping and nodes plus clean up
-    final_merged = pd.concat([new_merged_df, merged_df_relate], ignore_index=True)
-    final_merged = final_merged.fillna("")
-    final_merged = final_merged.drop_duplicates()
-
-    # Last step to create a more human readable format
-    results = []
-
-    # logic to create simplified output for human use
-    for index, row in final_merged.iterrows():
-        new_values = (
-            final_merged.at[index, "node_new"],
-            final_merged.at[index, "property_new"],
-        )
-        old_values = (
-            final_merged.at[index, "node_old"],
-            final_merged.at[index, "property_old"],
-        )
-
-        # Check for NA/None values in new_values and old_values
-        new_values_na = any(value == "" for value in new_values)
-        old_values_na = any(value == "" for value in old_values)
-
-        # logic flow to note if there are deletions, additions, rearrangements or static
-
-        if new_values_na and not old_values_na:
-            state = "DELETION"
-        elif old_values_na and not new_values_na:
-            state = "ADDITION"
-        elif new_values != old_values:
-            state = "CHANGED"
-        else:
-            state = "SAME"
-
-        # Append the row to the results list
-        results.append(
-            {
-                "state": state,
-                "node_old": old_values[0],
-                "property_old": old_values[1],
-                "version_old": old_model_version,
-                "node_new": new_values[0],
-                "property_new": new_values[1],
-                "version_new": new_model_version,
-            }
-        )
-
-    # Create a new DataFrame from the results list
-    comparison_df = pd.DataFrame(results)
-
-    # Drop rows where state is 'SAME' and clean up
-    comparison_df = comparison_df[comparison_df["state"] != "SAME"]
-    comparison_df = comparison_df.fillna("")
-    comparison_df = comparison_df.drop_duplicates()
-
-    # Upload files with better headers
-
-    comparison_mapping_file_name = f"{old_model_repository}_{old_model_version}_{new_model_repository}_{new_model_version}_comparison_{current_date}.tsv"
-
-    comparison_df_out = comparison_df
-
-    # # Change column names for prefect script for comparison
-    comparison_df_out.columns = [
-        "state",
-        "lift_from_node",
-        "lift_from_property",
-        "lift_from_version",
-        "lift_to_node",
-        "lift_to_property",
-        "lift_to_version",
-    ]
-
-    comparison_df_out.to_csv(
-        comparison_mapping_file_name,
-        sep="\t",
-        index=False,
-    )
-
-    file_ul(
-        bucket=bucket,
-        output_folder=output_folder,
-        sub_folder="",
-        newfile=comparison_mapping_file_name,
-    )
-
-    # Change relationship column names for prefect script output
-
-    relationship_mapping_file_name = f"{old_model_repository}_{old_model_version}_{new_model_repository}_{new_model_version}_relationship_{current_date}.tsv"
-
-    merged_df_relate.columns = output_column_names
-
-    merged_df_relate.to_csv(
-        relationship_mapping_file_name,
-        sep="\t",
-        index=False,
-    )
-
-    file_ul(
-        bucket=bucket,
-        output_folder=output_folder,
-        sub_folder="",
-        newfile=relationship_mapping_file_name,
-    )
-
-    # Change nodeship column names for prefect script output
-
-    nodes_mapping_file_name = f"{old_model_repository}_{old_model_version}_{new_model_repository}_{new_model_version}_nodes_{current_date}.tsv"
-
-    new_merged_df.columns = output_column_names
-
-    new_merged_df.to_csv(
-        nodes_mapping_file_name,
-        sep="\t",
-        index=False,
-    )
-
-    file_ul(
-        bucket=bucket,
-        output_folder=output_folder,
-        sub_folder="",
-        newfile=nodes_mapping_file_name,
-    )
-
-    # Change MAPPING column names for prefect script output
-    final_mapping_file_name = f"{old_model_repository}_{old_model_version}_{new_model_repository}_{new_model_version}_MAPPING_{current_date}.tsv"
-
-    final_merged_out = final_merged
-
-    final_merged_out.columns = output_column_names
-
-    # add the linkage properties onto the property data frame
-
-    final_merged_out.to_csv(
-        final_mapping_file_name,
-        sep="\t",
-        index=False,
-    )
-
-    # UPLOAD RELATIONSHIP file
-
-    file_ul(
-        bucket=bucket,
-        output_folder=output_folder,
-        sub_folder="",
-        newfile=final_mapping_file_name,
-    )
+    logger.info(f"Done. Outputs written to {output_folder}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -22,16 +22,6 @@ COLUMNS = [
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-# def read_yaml_from_github(url):
-#     response = requests.get(url)
-#     response.raise_for_status()
-#     return yaml.safe_load(response.text)
-
-
-# def get_version(yaml_data):
-#     version = yaml_data.get("Version", "insert version")
-#     return version.replace("v.", "").replace("v", "")
-
 def pull_model_data_files(model, version, file_type, output_file):
     if file_type == "model":
         url = f"https://raw.githubusercontent.com/CBIIT/{model}/{version}/model-desc/{model}.yml"
@@ -288,11 +278,6 @@ def runner(
     mapping_df = expand_semicolon_nodes(mapping_df)
     mapping_df = clean_up_partial_dups(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property")
     mapping_df = clean_up_partial_dups(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property")
-
-    # Remove as we don't need to write over the version data, it already exists in the input and we want to keep it consistent with the user input.
-    # for ver_col, yaml_data in [("lift_from_version", yaml_old), ("lift_to_version", yaml_new)]:
-    #     if mapping_df[ver_col].replace("", pd.NA).isna().any():
-    #         mapping_df[ver_col] = get_version(yaml_data)
 
     mapping_df = mapping_df.fillna("").drop_duplicates()
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -49,6 +49,7 @@ def parse_model(model_parsed, version):
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in node_list:
+        print(f"Things are getting pushed, right?")
         print(f"Parsing relationships for node: {node}")
         parent_nodes = model_parsed.get_parent_nodes(node)
         print(f"Parent nodes of node: {node} are: {parent_nodes}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -76,8 +76,8 @@ def build_mapping(df_from: pd.DataFrame, df_to: pd.DataFrame) -> pd.DataFrame:
 # ── user input ────────────────────────────────────────────────────────────────
 
 def user_input_location(df, value_node_col, value_property_col,
-                         missing_node_col, missing_property_col,
-                         missing_version_col, base_mode, direction):
+                        missing_node_col, missing_property_col,
+                        missing_version_col, base_mode, direction):
     logger = get_run_logger()
 
     df_missing = df[df[missing_property_col].isna()]
@@ -142,7 +142,7 @@ def expand_semicolon_nodes(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def clean_up_partial_dups(df, empty_node_col, empty_prop_col,
-                           value_node_col, value_prop_col) -> pd.DataFrame:
+                        value_node_col, value_prop_col) -> pd.DataFrame:
     indexes_to_remove = []
     for index, row in df.iterrows():
         if pd.isna(row[empty_node_col]) or pd.isna(row[empty_prop_col]):
@@ -253,9 +253,10 @@ def runner(
     mapping_df = clean_up_partial_dups(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property")
     mapping_df = clean_up_partial_dups(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property")
 
-    for ver_col, yaml_data in [("lift_from_version", yaml_old), ("lift_to_version", yaml_new)]:
-        if mapping_df[ver_col].replace("", pd.NA).isna().any():
-            mapping_df[ver_col] = get_version(yaml_data)
+    # Remove as we don't need to write over the version data, it already exists in the input and we want to keep it consistent with the user input.
+    # for ver_col, yaml_data in [("lift_from_version", yaml_old), ("lift_to_version", yaml_new)]:
+    #     if mapping_df[ver_col].replace("", pd.NA).isna().any():
+    #         mapping_df[ver_col] = get_version(yaml_data)
 
     mapping_df = mapping_df.fillna("").drop_duplicates()
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -37,7 +37,6 @@ def pull_model_data_files(model, version, file_type, output_file):
 
 # ── extraction ────────────────────────────────────────────────────────────────
 
-@task
 def parse_model(model_parsed, version):
     rows = []
     print(f"Starting to parse model for version: {version}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -59,7 +59,7 @@ def parse_model(model_parsed, version):
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in model_parsed.get_node_list():
-        #logger.info(f"Parsing relationships for node: {node}")
+        logger.info(f"Parsing relationships for node: {node}")
         for parent in model_parsed.get_parent_nodes(node):
             logger.info(f"Parsing parent node: {parent} of node: {node}")
             # handle top level nodes without parents - skip as they won't have a parent property to map to

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -51,6 +51,7 @@ def pull_model_data_files(model, version, file_type, output_file):
 def parse_model(model_parsed, version):
     rows = []
     logger = get_run_logger()
+    logger.info(f"Starting to parse model, {model_parsed} for version: {version}")
 
     for node in model_parsed.get_node_list():
         logger.info(f"Parsing node: {node}")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -1,4 +1,3 @@
-import yaml
 import requests
 import pandas as pd
 import os

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -40,28 +40,27 @@ def pull_model_data_files(model, version, file_type, output_file):
 @task
 def parse_model(model_parsed, version):
     rows = []
-    logger = get_run_logger()
-    logger.info(f"Starting to parse model for version: {version}")
+    print(f"Starting to parse model for version: {version}")
+    node_list = model_parsed.get_node_list()
 
-    for node in model_parsed.get_node_list():
-        logger.info(f"Parsing node: {node}")
+    for node in node_list:
+        print(f"Parsing node: {node}")
         for prop in model_parsed.get_node_props_list(node):
-            logger.info(f"Parsing property: {prop} of node: {node}")
+            # print(f"Parsing property: {prop} of node: {node}")
             rows.append({"node": node, "property": prop, "version": version})
 
-    for node in model_parsed.get_node_list():
-        logger.info(f"Parsing relationships for node: {node}")
-        logger.info(f"Parent nodes of node: {node} are: {model_parsed.get_parent_nodes(node)}")
-        for parent in model_parsed.get_parent_nodes(node):
-            logger.info(f"Parsing parent node: {parent} of node: {node}")
-            if not parent:
-                logger.info(f"Node: {node} has no parent nodes, skipping.")
-            else:
+    for node in node_list:
+        print(f"Parsing relationships for node: {node}")
+        parent_nodes = model_parsed.get_parent_nodes(node)
+        print(f"Parent nodes of node: {node} are: {parent_nodes}")
+        if len(parent_nodes) == 0:
+            print(f"Node: {node} has no parent nodes, skipping relationship parsing for this node.")
+        else:
+            print(
+                f"Node: {node} has parent nodes, parsing relationships for this node."
+            )
+            for parent in parent_nodes:
                 key_prop = model_parsed.get_node_key_prop(parent)
-                logger.info(f"key_prop for parent '{parent}': {repr(key_prop)}")  # repr() shows None vs empty string
-                if not key_prop:
-                    logger.warning(f"No key_prop found for parent '{parent}' of node '{node}', skipping.")
-                    continue
                 rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -5,6 +5,9 @@ import os
 from prefect import flow, get_run_logger, pause_flow_run
 from prefect.input import RunInput
 from src.utils import get_time, file_dl, file_ul
+from meval.parser import ModelParser
+import requests
+
 
 
 class InputValues(RunInput):
@@ -19,45 +22,71 @@ COLUMNS = [
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-def read_yaml_from_github(url):
+# def read_yaml_from_github(url):
+#     response = requests.get(url)
+#     response.raise_for_status()
+#     return yaml.safe_load(response.text)
+
+
+# def get_version(yaml_data):
+#     version = yaml_data.get("Version", "insert version")
+#     return version.replace("v.", "").replace("v", "")
+
+def pull_model_data_files(model, version, file_type, output_file):
+    if file_type == "model":
+        url = f"https://raw.githubusercontent.com/CBIIT/{model}/{version}/model-desc/{model}.yml"
+    elif file_type == "props":
+        url = f"https://raw.githubusercontent.com/CBIIT/{model}/{version}/model-desc/{model}-{file_type}.yml"
     response = requests.get(url)
     response.raise_for_status()
-    return yaml.safe_load(response.text)
 
+    with open(output_file, 'w') as f:
+        f.write(response.text)
 
-def get_version(yaml_data):
-    version = yaml_data.get("Version", "insert version")
-    return version.replace("v.", "").replace("v", "")
-
+    return output_file
 
 # ── extraction ────────────────────────────────────────────────────────────────
 
-def extract_properties(yaml_data, side: str) -> pd.DataFrame:
-    """side is either 'from' or 'to'."""
-    version = get_version(yaml_data)
-    rows = [
-        {f"lift_{side}_node": node, f"lift_{side}_property": prop, f"lift_{side}_version": version}
-        for node, props in yaml_data["Nodes"].items()
-        for prop in props["Props"]
-    ]
-    return pd.DataFrame(rows)
+def parse_model(model_parsed, version):
+    rows = []
+
+    for node in model_parsed.get_node_list():
+        for prop in model_parsed.get_node_props_list(node):
+            rows.append({"node": node, "property": prop, "version": version})
+
+    for node in model_parsed.get_node_list():
+        for parent in model_parsed.get_parent_nodes(node):
+            key_prop = model_parsed.get_node_key_prop(parent)
+            rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
+
+    return pd.DataFrame(rows, columns=["node", "property", "version"])
+
+# def extract_properties(yaml_data, side: str) -> pd.DataFrame:
+#     """side is either 'from' or 'to'."""
+#     version = get_version(yaml_data)
+#     rows = [
+#         {f"lift_{side}_node": node, f"lift_{side}_property": prop, f"lift_{side}_version": version}
+#         for node, props in yaml_data["Nodes"].items()
+#         for prop in props["Props"]
+#     ]
+#     return pd.DataFrame(rows)
 
 
-def extract_relationships(yaml_data, side: str) -> pd.DataFrame:
-    """side is either 'from' or 'to'."""
-    version = get_version(yaml_data)
-    rows = [
-        {
-            f"lift_{side}_node": src,
-            f"lift_{side}_property": f"{dst}.{dst}_id",
-            f"lift_{side}_version": version,
-        }
-        for rel in yaml_data["Relationships"].values()
-        for ends in rel["Ends"]
-        for src, dst in [(ends.get("Src"), ends.get("Dst"))]
-        if src and dst
-    ]
-    return pd.DataFrame(rows)
+# def extract_relationships(yaml_data, side: str) -> pd.DataFrame:
+#     """side is either 'from' or 'to'."""
+#     version = get_version(yaml_data)
+#     rows = [
+#         {
+#             f"lift_{side}_node": src,
+#             f"lift_{side}_property": f"{dst}.{dst}_id",
+#             f"lift_{side}_version": version,
+#         }
+#         for rel in yaml_data["Relationships"].values()
+#         for ends in rel["Ends"]
+#         for src, dst in [(ends.get("Src"), ends.get("Dst"))]
+#         if src and dst
+#     ]
+#     return pd.DataFrame(rows)
 
 
 # ── merging ───────────────────────────────────────────────────────────────────
@@ -206,13 +235,11 @@ def build_comparison(df: pd.DataFrame, old_version: str, new_version: str) -> pd
 def runner(
     bucket: str,
     runner: str,
-    old_model_repository: str = "ccdi-model",
-    new_model_repository: str = "ccdi-model",
-    old_model_version: str = "",
-    new_model_version: str = "",
-    old_model_file_location: str = "model-desc/ccdi-model.yml",
-    new_model_file_location: str = "model-desc/ccdi-model.yml",
-    base_mode: bool = False,
+    old_model_repository: str = "ccdi-dcc-model",
+    new_model_repository: str = "cds-model",
+    old_model_version: str = "1.0.0",
+    new_model_version: str = "11.0.4-GC_Release",
+    base_mode: bool = True,
     mapping_file: str = "path_to/mapping_file/in/s3_bucket.tsv",
 ):
     logger = get_run_logger()
@@ -226,22 +253,46 @@ def runner(
         file_dl(bucket, mapping_file)
 
     # ── fetch models ──────────────────────────────────────────────────────────
-    old_url = f"https://raw.githubusercontent.com/CBIIT/{old_model_repository}/{old_model_version}/{old_model_file_location}"
-    new_url = f"https://raw.githubusercontent.com/CBIIT/{new_model_repository}/{new_model_version}/{new_model_file_location}"
 
-    yaml_old = read_yaml_from_github(old_url)
+    old_model_file_yaml = pull_model_data_files(model=old_model_repository, version=old_model_version, file_type="model", output_file="old_model.yaml")
     logger.info(f"{old_model_repository} at {old_model_version} found.")
-    yaml_new = read_yaml_from_github(new_url)
-    logger.info(f"{new_model_repository} at {new_model_version} found.")
+    
+    old_props_file_yaml = pull_model_data_files(model=old_model_repository, version=old_model_version, file_type="props", output_file="old_props.yaml")
+    logger.info(f"{old_model_repository} properties at {old_model_version} found.")
+        
+    new_model_file_yaml = pull_model_data_files(model=new_model_repository, version=new_model_version, file_type="model", output_file="new_model.yaml")
+    logger.info(f"{new_model_repository} at {new_model_version} found.")    
+    
+    new_props_file_yaml = pull_model_data_files(model=new_model_repository, version=new_model_version, file_type="props", output_file="new_props.yaml")
+    logger.info(f"{new_model_repository} properties at {new_model_version} found.")
+
+
+    # ── Create MDF objects via MEVAL (mdf) parsing ─────────────────────────────────
+    model_parsed_old = ModelParser(
+        model_file=old_model_file_yaml,
+        props_file=old_props_file_yaml,
+        handle=old_model_version
+    )
+
+    model_parsed_new = ModelParser(
+        model_file=new_model_file_yaml,
+        props_file=new_props_file_yaml,
+        handle=new_model_version
+    )
+
+    df_old = parse_model(model_parsed_old, old_model_version)
+    df_new = parse_model(model_parsed_new, new_model_version)
+
 
     # ── build or load mapping ─────────────────────────────────────────────────
     if mapping_file:
         mapping_df = pd.read_csv(os.path.basename(mapping_file), sep="\t")
         mapping_df.columns = COLUMNS
     else:
-        props_df = build_mapping(extract_properties(yaml_old, "from"), extract_properties(yaml_new, "to"))
-        rels_df  = build_mapping(extract_relationships(yaml_old, "from"), extract_relationships(yaml_new, "to"))
-        mapping_df = pd.concat([props_df, rels_df], ignore_index=True)
+        df_from = df_old.rename(columns={"node": "lift_from_node", "property": "lift_from_property", "version": "lift_from_version"})
+        df_to   = df_new.rename(columns={"node": "lift_to_node",   "property": "lift_to_property",   "version": "lift_to_version"})
+
+        mapping_df = build_mapping(df_from, df_to)
 
         user_input_location(mapping_df, "lift_from_node", "lift_from_property", "lift_to_node",   "lift_to_property",   "lift_to_version",   base_mode, "fromto")
         user_input_location(mapping_df, "lift_to_node",   "lift_to_property",   "lift_from_node", "lift_from_property", "lift_from_version", base_mode, "tofrom")

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -51,7 +51,7 @@ def pull_model_data_files(model, version, file_type, output_file):
 def parse_model(model_parsed, version):
     rows = []
     logger = get_run_logger()
-    logger.info(f"Starting to parse model, {model_parsed} for version: {version}")
+    logger.info(f"Starting to parse model for version: {version}")
 
     for node in model_parsed.get_node_list():
         logger.info(f"Parsing node: {node}")
@@ -61,6 +61,7 @@ def parse_model(model_parsed, version):
 
     for node in model_parsed.get_node_list():
         logger.info(f"Parsing relationships for node: {node}")
+        logger.info(f"Parent nodes of node: {node} are: {model_parsed.get_parent_nodes(node)}")
         for parent in model_parsed.get_parent_nodes(node):
             logger.info(f"Parsing parent node: {parent} of node: {node}")
             # handle top level nodes without parents - skip as they won't have a parent property to map to

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -46,7 +46,6 @@ def parse_model(model_parsed, version):
     for node in node_list:
         print(f"Parsing node: {node}")
         for prop in model_parsed.get_node_props_list(node):
-            # print(f"Parsing property: {prop} of node: {node}")
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in node_list:
@@ -61,7 +60,10 @@ def parse_model(model_parsed, version):
             )
             for parent in parent_nodes:
                 key_prop = model_parsed.get_node_key_prop(parent)
-                rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
+                if not key_prop:
+                    print(f"No key_prop found for parent '{parent}' of node '{node}', skipping.")
+                    continue
+                rows.append({"node": node, "property": f"{parent}.{key_prop}", "version": version})
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])
 

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -2,7 +2,7 @@ import yaml
 import requests
 import pandas as pd
 import os
-from prefect import flow, get_run_logger, pause_flow_run
+from prefect import flow, task, get_run_logger, pause_flow_run
 from prefect.input import RunInput
 from src.utils import get_time, file_dl, file_ul
 from meval.parser import ModelParser
@@ -47,15 +47,21 @@ def pull_model_data_files(model, version, file_type, output_file):
 
 # ── extraction ────────────────────────────────────────────────────────────────
 
+@task
 def parse_model(model_parsed, version):
     rows = []
+    logger = get_run_logger()
 
     for node in model_parsed.get_node_list():
+        logger.info(f"Parsing node: {node}")
         for prop in model_parsed.get_node_props_list(node):
+            logger.info(f"Parsing property: {prop} of node: {node}")
             rows.append({"node": node, "property": prop, "version": version})
 
     for node in model_parsed.get_node_list():
+        logger.info(f"Parsing relationships for node: {node}")
         for parent in model_parsed.get_parent_nodes(node):
+            logger.info(f"Parsing parent node: {parent} of node: {node}")
             # handle top level nodes without parents - skip as they won't have a parent property to map to
             if not parent:
                 continue

--- a/workflows/model_mapping_maker.py
+++ b/workflows/model_mapping_maker.py
@@ -54,11 +54,14 @@ def parse_model(model_parsed, version):
         logger.info(f"Parent nodes of node: {node} are: {model_parsed.get_parent_nodes(node)}")
         for parent in model_parsed.get_parent_nodes(node):
             logger.info(f"Parsing parent node: {parent} of node: {node}")
-            # handle top level nodes without parents - skip as they won't have a parent property to map to
             if not parent:
-                logger.info(f"Node: {node} has no parent nodes, skipping relationship parsing for this node.")
+                logger.info(f"Node: {node} has no parent nodes, skipping.")
             else:
                 key_prop = model_parsed.get_node_key_prop(parent)
+                logger.info(f"key_prop for parent '{parent}': {repr(key_prop)}")  # repr() shows None vs empty string
+                if not key_prop:
+                    logger.warning(f"No key_prop found for parent '{parent}' of node '{node}', skipping.")
+                    continue
                 rows.append({"node": node, "property": f"{parent}.{key_prop}_id", "version": version})
 
     return pd.DataFrame(rows, columns=["node", "property", "version"])


### PR DESCRIPTION
This pull request introduces a new deployment configuration for testing the model mapping maker workflow and updates several dependencies in the requirements file. The most important changes are grouped below:

Dependency updates:

* Upgraded `bento-mdf` from version 0.13.0 to 0.13.1 in `requirements_python3.13_prefect3.txt`.
* Upgraded `neo4j` from version 6.1.0 to 6.2.0 in `requirements_python3.13_prefect3.txt`.
* Added new dependencies `ctos-meval==1.1.1` and `neo4j-viz==1.0.0` to `requirements_python3.13_prefect3.txt`.

Major changes:
- Updates to the parsing, now using the MDF parser via the MEVAL library
- Updates to the formation of the mapping file and integration of previous mapping files.
- Updates to the input and outputs to only require a mapping file instead of needing nodes and relationships.
- Updates to the guided input section, streamlined. Probable deprecation in the future as this is a very tedious path for mapping.
- Clean up of deployment yaml, removing deployments that have been commented out for a while now.