### PR TITLE
Update inferred_type for 'out' file extension

### DIFF
--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -1283,6 +1283,11 @@ def check_file_extension_type_match(file_df: DataFrame) -> str:
                 "txt",
                 "tsv",
             ]  # if the extension is longer than 6 characters, likely not a standard extension
+        elif "out" == file_extension:
+            inferred_type = [
+                "txt",
+                "tsv",
+            ]  # if there is an "out" extension, likely a text or tsv file
         elif "dcm" == file_extension:
             inferred_type = "dicom"
         elif "fq" == file_extension:


### PR DESCRIPTION
Refactor inferred_type assignment for file extensions. Now allows .out to be assumed as a txt or tsv file.