### PR TITLE
Drop Duplicates During Saving

### DIFF
--- a/workflows/gc_liftover_helper.py
+++ b/workflows/gc_liftover_helper.py
@@ -50,6 +50,9 @@ def save_tsvs_to_folder(sheet_dfs, output_path):
         data_cols = [col for col in df.columns if col not in key_cols]
         df = df[df[data_cols].notna().any(axis=1)]
 
+        # drop duplicate rows
+        df = df.drop_duplicates()
+
         # save as TSV files
         file_path = os.path.join(output_path, f"{name}.tsv")
         df.to_csv(file_path, sep="\t", index=False)


### PR DESCRIPTION
## Overview
Due to multiple samples linking to the same file in the DCC-CCDI model, duplicate rows were present in the geneomic_info file for some studies. This PR resolves that issue by adding duplicate removal to dataframes post-processing. 

## Key Changes
- drop duplicates during saving to collapse duplicate file rows
- duplicate removal now occurs in all TSVs after post-processing, not just during loading