### PR TITLE
fix: change semicolon to pipe in gc_liftover_helper

### DIFF
--- a/workflows/gc_liftover_helper.py
+++ b/workflows/gc_liftover_helper.py
@@ -15,6 +15,7 @@ def load_tsvs_from_folder(folder_path):
             file_path = os.path.join(folder_path, file)
             file_name = re.sub(r'_\d{4}-\d{2}-\d{2}', '', file).replace(".tsv", "")
             df = pd.read_csv(file_path, sep="\t").astype(str).replace('nan', pd.NA)
+            df = df.replace(';', '|', regex=True)
             df = df.drop_duplicates()
             sheet_dfs[file_name] = df
             files_loaded += 1


### PR DESCRIPTION
## Summary
CCDI DCC TSV files use ; as a list separator, but GC requires |. This PR fixes delimiter while loading the TSV files into dataframes.

## Key Changes
Modified Function: load_tsvs_from_folder

Implementation: Applied a dataframe-wide regex replacement (df.replace(';', '|', regex=True)) after the data is cast to strings and nan values are handled. This catches semicolons embedded within string cells across all columns.