### PR TITLE
Change 'Error' to 'ERROR' in property_dict

### DIFF
--- a/src/s3_validationry_refactored.py
+++ b/src/s3_validationry_refactored.py
@@ -521,7 +521,7 @@ def validate_integer_numeric_checks_one_sheet(
             # if the warning flag was tripped
             if WARN_FLAG:
                 WARN_FLAG = False
-                property_dict["check"] = "Error"
+                property_dict["check"] = "ERROR"
                 # itterate over that list and print out the values
                 enum_print = ",".join([str(i) for i in error_rows])
                 property_dict["error row"] = enum_print
@@ -791,7 +791,7 @@ def validate_age_one_sheet(node_name: str, file_object):
         # if the warning flag was tripped
         if WARN_FLAG:
             WARN_FLAG = False
-            property_dict["check"] = "Error"
+            property_dict["check"] = "ERROR"
             # itterate over that list and print out the values
             enum_print = ",".join([str(i) for i in error_rows])
             property_dict["error row"] = enum_print


### PR DESCRIPTION
This pull request makes a small but important change to the way error statuses are reported in the validation logic. Specifically, it updates the value assigned to the `"check"` key in `property_dict` from `"Error"` to `"ERROR"` for consistency and standardization in error reporting.

- Standardization of error reporting:
  * Updated the value of `property_dict["check"]` from `"Error"` to `"ERROR"` in both the `validate_integer_numeric_checks_one_sheet` and `validate_age_one_sheet` functions for consistency in error status formatting. [[1]](diffhunk://#diff-112d5c4fe5c5f66abd85c1288c1d9fdeeee8198b28daeeb6d5724fed6f014c53L524-R524) [[2]](diffhunk://#diff-112d5c4fe5c5f66abd85c1288c1d9fdeeee8198b28daeeb6d5724fed6f014c53L794-R794)