### PR TITLE
Ccdidc 2594 validation db checks

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1825,7 +1825,7 @@ deployments:
       - prefect.deployments.steps.git_clone:
           id: clone-step
           repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: main
+          branch: CCDIDC-2594-validation-db-checks
       - prefect.deployments.steps.pip_install_requirements:
           requirements_file: requirements_python3.13_prefect3.txt
           directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1808,3 +1808,31 @@ deployments:
       name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {} 
+
+  - name: TEST-validate-db-data-32gb-v3
+    version: null
+    tags: ["TEST","SVB","CCDIDC-2594","Centralized Worker","DCC","V3"]
+    description: Validate a memgraph database data
+    entrypoint: workflows/validate_db_data.py:validate_db_data
+    schedule: null
+
+    # flow-specific parameters
+    parameters:
+      bucket: "ccdi-validation"
+
+    # pull action to overwrite from file pull action
+    pull:
+      - prefect.deployments.steps.git_clone:
+          id: clone-step
+          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
+          branch: main
+      - prefect.deployments.steps.pip_install_requirements:
+          requirements_file: requirements_python3.13_prefect3.txt
+          directory: "{{ clone-step.directory }}"
+          stream_output: False
+
+    # infra-specific fields
+    work_pool:
+      name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
+      work_queue_name: null
+      job_variables: {}

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1808,31 +1808,3 @@ deployments:
       name: ccdi-dcc-8gb-prefect-3.4.19-python3.13
       work_queue_name: null
       job_variables: {} 
-
-  - name: TEST-validate-db-data-32gb-v3
-    version: null
-    tags: ["TEST","SVB","CCDIDC-2594","Centralized Worker","DCC","V3"]
-    description: Validate a memgraph database data
-    entrypoint: workflows/validate_db_data.py:validate_db_data
-    schedule: null
-
-    # flow-specific parameters
-    parameters:
-      bucket: "ccdi-validation"
-
-    # pull action to overwrite from file pull action
-    pull:
-      - prefect.deployments.steps.git_clone:
-          id: clone-step
-          repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-Prefect_Pipeline.git
-          branch: CCDIDC-2594-validation-db-checks
-      - prefect.deployments.steps.pip_install_requirements:
-          requirements_file: requirements_python3.13_prefect3.txt
-          directory: "{{ clone-step.directory }}"
-          stream_output: False
-
-    # infra-specific fields
-    work_pool:
-      name: ccdi-dcc-32gb-prefect-3.4.19-python3.13
-      work_queue_name: null
-      job_variables: {}

--- a/src/neo4j_data_tools.py
+++ b/src/neo4j_data_tools.py
@@ -1200,7 +1200,7 @@ def compare_id_input_db_dcc(
         i_node = comparison_df.loc[i, "node"]
         i_node_guid = comparison_df.loc[i, "tsv_id"]  # still tsv_id in parsed df
         i_node_guid_count = comparison_df.loc[i, "tsv_count"]
-        db_node_guid_count = len(db_id_pulled_dict[i_study_id][i_node])
+        db_node_guid_count = len(set(db_id_pulled_dict[i_study_id][i_node]))
         db_node_guid = db_id_pulled_dict[i_study_id][i_node]
         if i_node_guid_count == db_node_guid_count:
             comparison_df.loc[i, "count_check"] = "Equal"

--- a/src/neo4j_data_tools.py
+++ b/src/neo4j_data_tools.py
@@ -126,11 +126,11 @@ RETURN
 """
     all_nodes_entries_study_cypher_query: str = """
 MATCH (study:study {{study_id: "{study_id}"}})<-[*0..6]-(node)
-RETURN labels(node) AS NodeLabel, COUNT(node) AS NodeCount
-"""
+RETURN labels(node) AS NodeLabel, COUNT(DISTINCT node) AS NodeCount
+""" 
     node_id_cypher_query_query: str = """
 MATCH (study:study{{study_id:"{study_id}"}})<-[*1..7]-(node:{node})
-RETURN node.guid AS id
+RETURN DISTINCT node.guid AS id 
 """
     node_property_uniq_value: str = """
 MATCH (n:{node})


### PR DESCRIPTION
This pull request makes improvements to how node counts are calculated and compared in the Neo4j data tools, ensuring more accurate results by counting only unique nodes and IDs. The main changes are:

**Query accuracy improvements:**

* In the `DBCypherQueryDCC` class, the Cypher queries now use `COUNT(DISTINCT node)` and `RETURN DISTINCT node.guid AS id` to ensure only unique nodes and IDs are counted and returned.

**Comparison logic update:**

* In the `compare_id_input_db_dcc` function, the count of node GUIDs from the database is now calculated using `len(set(...))` to count only unique IDs, preventing duplicate entries from affecting the comparison.